### PR TITLE
Add melody tests

### DIFF
--- a/melody-generator.py
+++ b/melody-generator.py
@@ -201,6 +201,9 @@ def generate_melody(key: str, num_notes: int, chord_progression: List[str], moti
     Returns:
         List[str]: Generated melody as a list of note names.
     """
+    if num_notes < motif_length:
+        raise ValueError("num_notes must be greater than or equal to motif_length")
+
     notes_in_key = SCALE[key]
     # Generate the initial motif.
     melody = generate_motif(motif_length, key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+addopts = "-vv"

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -1,0 +1,36 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import pytest
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "melody-generator.py"
+spec = importlib.util.spec_from_file_location("melody_generator", MODULE_PATH)
+melody_generator = importlib.util.module_from_spec(spec)
+
+# Provide a minimal stub for the 'mido' module so the import succeeds
+stub_mido = types.ModuleType("mido")
+stub_mido.Message = lambda *args, **kwargs: None
+stub_mido.MidiFile = lambda *args, **kwargs: types.SimpleNamespace(tracks=[])
+stub_mido.MidiTrack = lambda *args, **kwargs: []
+stub_mido.MetaMessage = lambda *args, **kwargs: None
+stub_mido.bpm2tempo = lambda bpm: bpm
+sys.modules.setdefault("mido", stub_mido)
+
+spec.loader.exec_module(melody_generator)
+note_to_midi = melody_generator.note_to_midi
+generate_melody = melody_generator.generate_melody
+
+
+def test_note_to_midi_sharp_and_flat():
+    assert note_to_midi('C#4') == note_to_midi('Db4')
+    assert note_to_midi('F#5') == note_to_midi('Gb5')
+
+
+def test_generate_melody_length_and_error():
+    chords = ['C', 'G', 'Am', 'F']
+    melody = generate_melody('C', 8, chords, motif_length=4)
+    assert len(melody) == 8
+
+    with pytest.raises(ValueError):
+        generate_melody('C', 3, chords, motif_length=4)


### PR DESCRIPTION
## Summary
- raise error when `num_notes` < `motif_length`
- add pytest config
- add tests for `note_to_midi` and `generate_melody`

## Testing
- `pytest -q`