### PR TITLE
Add Docker support for melody generator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+.git
+root/
+root*/
+AGENTS.md
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 5000
+
+ENTRYPOINT ["python", "web_gui.py"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ python web_gui.py
 ```
 Then open `http://localhost:5000` in your browser to generate melodies and download the MIDI file.
 
+## Docker Usage
+Build the image and run the web interface:
+```bash
+docker build -t melody-generator .
+docker run -p 5000:5000 melody-generator
+```
+Then visit `http://localhost:5000` in your browser.
+
 # Parameters
 - **Key**: Enter the key for the melody (e.g., C, C#, Dm, etc.). Both major and minor keys are supported.
 - **BPM**: Adjust the tempo using the slider (e.g., 120 BPM).


### PR DESCRIPTION
## Summary
- provide a Dockerfile to run the web interface
- ignore build files via `.dockerignore`
- document Docker usage in README

## Testing
- `pytest -q`