### PR TITLE
Move web templates

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,9 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 600px;
+    margin: 2rem auto;
+    text-align: center;
+}
+form {
+    margin-top: 1rem;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Melody Generator</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <h1>Generate Melody</h1>
+  <form method="post">
+    Key:
+    <select name="key">
+      {% for k in scale %}<option value="{{k}}">{{k}}</option>{% endfor %}
+    </select><br>
+    Chord progression (comma separated):<br>
+    <input name="chords"><br>
+    <label><input type="checkbox" name="random_chords" value="1"> Random chords</label><br>
+    BPM: <input type="number" name="bpm" value="120"><br>
+    Time Signature: <input name="timesig" value="4/4"><br>
+    Number of notes: <input type="number" name="notes" value="16"><br>
+    Motif length: <input type="number" name="motif_length" value="4"><br>
+    <label><input type="checkbox" name="harmony" value="1"> Harmony</label><br>
+    <label><input type="checkbox" name="random_rhythm" value="1"> Random rhythm</label><br>
+    <input type="submit" value="Generate">
+  </form>
+</body>
+</html>

--- a/templates/play.html
+++ b/templates/play.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Melody Generated</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <h1>Your Melody</h1>
+  <audio controls autoplay>
+    <source src="data:audio/midi;base64,{{ data }}" type="audio/midi">
+    Your browser does not support the audio tag.
+  </audio>
+  <p><a download="melody.mid" href="data:audio/midi;base64,{{ data }}">Download MIDI</a></p>
+  <p><a href="/">Generate another</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- use Flask `render_template` with template and static folders
- split inline HTML into `index.html` and `play.html`
- add basic CSS for layout

## Testing
- `pytest -q`
- `python -m flask --app web_gui run --no-reload --port 5000`

------
https://chatgpt.com/codex/tasks/task_e_6841c1bb19ec8321ba441f0cbb351008