### PR TITLE
Add counterpoint and multi-track features

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,8 @@
     Number of notes: <input type="number" name="notes" value="16"><br>
     Motif length: <input type="number" name="motif_length" value="4"><br>
     <label><input type="checkbox" name="harmony" value="1"> Harmony</label><br>
+    Counterpoint: <input type="checkbox" name="counterpoint" value="1"><br>
+    Harmony lines: <input type="number" name="harmony_lines" value="0"><br>
     <label><input type="checkbox" name="random_rhythm" value="1"> Random rhythm</label><br>
     <input type="submit" value="Generate">
   </form>


### PR DESCRIPTION
## Summary
- implement harmony/counterpoint generation functions
- allow create_midi_file to write extra melody lines
- expose new options via CLI, GUI and web interface
- update HTML form for additional options
- add tests covering extra tracks

## Testing
- `pytest -q`
- `pytest tests/test_web_gui.py::test_index_route -q`

------
https://chatgpt.com/codex/tasks/task_e_684377895b608321b43430a459775da8