### PR TITLE
Fix ruff command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ so they do not need to be installed in order to run them.
 Lint the project using [ruff](https://github.com/astral-sh/ruff):
 
 ```bash
-ruff .
+ruff check .
 ```
 
 To build the Docker image locally run:


### PR DESCRIPTION
## Summary
- document `ruff check .` in the README instead of `ruff .`

## Testing
- `ruff check .`
- `pytest -q`