### PR TITLE
Fix extra track handling

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -568,7 +568,12 @@ def create_midi_file(
             harmony_track.append(h_on)
             harmony_track.append(h_off)
         for line, t in zip(extra_tracks or [], extra_midi_tracks):
-            # Write corresponding notes for any extra melody lines
+            # Write corresponding notes for any extra melody lines.  Some lines
+            # may be shorter than ``melody`` so guard against ``IndexError`` by
+            # skipping notes that do not exist.  This allows callers to supply
+            # partial tracks without needing to manually pad them out.
+            if i >= len(line):
+                continue
             m = note_to_midi(line[i])
             x_on = Message('note_on', note=m, velocity=velocity, time=0)
             x_off = Message('note_off', note=m, velocity=velocity, time=note_duration)

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -76,3 +76,25 @@ def test_extra_tracks_created(tmp_path):
     mid = DummyMidiFile.last_instance
     assert mid is not None
     assert len(mid.tracks) == 1 + 2
+
+
+def test_extra_tracks_shorter_line(tmp_path):
+    chords = ['C', 'G', 'Am', 'F']
+    melody = generate_melody('C', 6, chords, motif_length=4)
+    harmony = generate_harmony_line(melody)[:3]
+    cp = generate_counterpoint_melody(melody, 'C')[:5]
+    out = tmp_path / 'short.mid'
+    create_midi_file(
+        melody,
+        120,
+        (4, 4),
+        str(out),
+        harmony=False,
+        pattern=[0.25],
+        extra_tracks=[harmony, cp],
+    )
+    mid = DummyMidiFile.last_instance
+    assert mid is not None
+    assert len(mid.tracks) == 1 + 2
+    assert len(mid.tracks[1]) == 2 * len(harmony)
+    assert len(mid.tracks[2]) == 2 * len(cp)


### PR DESCRIPTION
## Summary
- prevent `create_midi_file` from indexing beyond available notes in extra tracks
- test that shorter harmony/counterpoint lines are handled gracefully

## Testing
- `pytest -q`