### PR TITLE
Add inline comments

### DIFF
--- a/melody_generator/__main__.py
+++ b/melody_generator/__main__.py
@@ -6,7 +6,10 @@ package can be launched as a script.  Keeping the logic in
 installed ``melody-generator`` console script and during testing.
 """
 
+# Reuse the package level ``main`` function so both ``python -m`` and the
+# installed console script behave identically.
 from . import main
 
 if __name__ == "__main__":
+    # Delegate execution to the package entry point
     main()

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -321,6 +321,7 @@ class MelodyGeneratorGUI:
 
     def run(self) -> None:
         """Start the Tk event loop."""
+        # Hand control over to Tkinter
         self.root.mainloop()
 
     def _collect_settings(self) -> Dict:
@@ -341,6 +342,7 @@ class MelodyGeneratorGUI:
 
     def _apply_settings(self, settings: Dict) -> None:
         """Set widget values based on ``settings`` dictionary."""
+        # Ignore empty dictionaries to avoid resetting controls unnecessarily
         if not settings:
             return
         self.key_var.set(settings.get("key", self.key_var.get()))

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -18,7 +18,8 @@ from typing import List
 from flask import Flask, render_template, request, flash
 import base64
 
-# Import the core melody generation package.
+# Import the core melody generation package dynamically so the
+# Flask app can live in a separate module without circular imports.
 melody_generator = import_module("melody_generator")
 
 # Pull the functions and data structures we need from the loaded module.
@@ -118,4 +119,5 @@ def index():
 # ``pragma: no cover`` keeps test coverage tools from complaining when
 # this block is skipped during automated testing.
 if __name__ == '__main__':  # pragma: no cover - manual usage
+    # Launch the development server
     app.run(debug=True)

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -8,6 +8,8 @@ import pytest
 
 def load_module():
     """Load melody-generator with stubbed dependencies."""
+    # Create minimal replacements for optional packages so the tests
+    # can run without installing them.
     stub_mido = types.ModuleType("mido")
     class DummyMidiFile:
         last_instance = None
@@ -87,8 +89,10 @@ def test_cli_subprocess_creates_file(tmp_path):
         encoding="utf-8",
     )
     env = os.environ.copy()
+    # Point PYTHONPATH at our stub directory so the subprocess imports them
     env["PYTHONPATH"] = f"{stub_dir}:{env.get('PYTHONPATH','')}"
     output = tmp_path / "out.mid"
+    # Execute the CLI in a subprocess to ensure the console script works end-to-end
     subprocess.run(
         [
             sys.executable,
@@ -159,6 +163,7 @@ def test_generate_button_click(tmp_path, monkeypatch):
         lambda **k: str(out),
         raising=False,
     )
+    # Capture any messagebox calls so we can assert on them later
     errs = []
     infos = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- document default settings path and stubbed load/save helpers
- expand comments for rhythm patterns and chord progression creation
- clarify note conversion logic and CLI workflow
- document GUI helper methods and web app entry point
- comment test helpers for clarity

## Testing
- `pytest -q`