### PR TITLE
Enforce positive CLI values

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -648,6 +648,17 @@ def run_cli() -> None:
     # Parse the provided CLI arguments
     args = parser.parse_args()
 
+    # Basic numeric sanity checks
+    if args.bpm <= 0:
+        logging.error("BPM must be a positive integer.")
+        sys.exit(1)
+    if args.notes <= 0:
+        logging.error("Number of notes must be a positive integer.")
+        sys.exit(1)
+    if args.motif_length <= 0:
+        logging.error("Motif length must be a positive integer.")
+        sys.exit(1)
+
     # Validate key and chord progression.
     if args.key not in SCALE:
         logging.error("Invalid key provided.")

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -246,3 +246,30 @@ def test_cli_invalid_timesig_exits(tmp_path):
     with pytest.raises(SystemExit):
         mod.run_cli()
     sys.argv = old
+
+
+def test_cli_non_positive_values_exit(tmp_path):
+    mod, _, _ = load_module()
+    out = tmp_path / "bad.mid"
+    argv = [
+        "prog",
+        "--key",
+        "C",
+        "--chords",
+        "C,G",
+        "--bpm",
+        "0",
+        "--timesig",
+        "4/4",
+        "--notes",
+        "-1",
+        "--motif_length",
+        "0",
+        "--output",
+        str(out),
+    ]
+    old = sys.argv
+    sys.argv = argv
+    with pytest.raises(SystemExit):
+        mod.run_cli()
+    sys.argv = old


### PR DESCRIPTION
## Summary
- check BPM, number of notes and motif length in `run_cli`
- add regression test for negative CLI values

## Testing
- `pytest -q`