### PR TITLE
Add denominator validation in GUI

### DIFF
--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -258,6 +258,8 @@ class MelodyGeneratorGUI:
             if len(ts_parts) != 2:
                 raise ValueError
             numerator, denominator = map(int, ts_parts)
+            if denominator <= 0:
+                raise ValueError
         except ValueError:
             # Show one error message for any invalid numeric input
             messagebox.showerror(

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -223,6 +223,42 @@ def test_generate_button_click_non_positive(tmp_path, monkeypatch):
     assert errs
 
 
+def test_generate_button_click_invalid_denominator(tmp_path, monkeypatch):
+    mod, gui_mod, _ = load_module()
+    gui = gui_mod.MelodyGeneratorGUI.__new__(gui_mod.MelodyGeneratorGUI)
+    gui.generate_melody = lambda *a, **k: []
+    gui.create_midi_file = lambda *a, **k: None
+    gui.harmony_line_fn = None
+    gui.counterpoint_fn = None
+    gui.save_settings = None
+    gui.rhythm_pattern = None
+    gui.key_var = types.SimpleNamespace(get=lambda: "C")
+    gui.bpm_var = types.SimpleNamespace(get=lambda: 120)
+    gui.timesig_var = types.SimpleNamespace(get=lambda: "4/0")
+    gui.notes_var = types.SimpleNamespace(get=lambda: 4)
+    gui.motif_entry = types.SimpleNamespace(get=lambda: "2")
+    gui.harmony_var = types.SimpleNamespace(get=lambda: False)
+    gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
+    gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
+    lb = types.SimpleNamespace(curselection=lambda: (0,), get=lambda idx: "C")
+    gui.chord_listbox = lb
+
+    monkeypatch.setattr(
+        gui_mod.filedialog,
+        "asksaveasfilename",
+        lambda **k: str(tmp_path / "x.mid"),
+        raising=False,
+    )
+    errs = []
+    monkeypatch.setattr(
+        gui_mod.messagebox, "showerror", lambda *a, **k: errs.append(a), raising=False
+    )
+
+    gui._generate_button_click()
+
+    assert errs
+
+
 def test_cli_invalid_timesig_exits(tmp_path):
     mod, _, _ = load_module()
     out = tmp_path / "bad.mid"


### PR DESCRIPTION
## Summary
- validate that the time signature denominator is > 0 in `MelodyGeneratorGUI`
- test GUI error handling when denominator is non-positive

## Testing
- `pytest -q`