### PR TITLE
Add key validation in web GUI

### DIFF
--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -54,6 +54,10 @@ def index():
         # Extract user selections, applying sensible defaults when
         # values are missing.
         key = request.form.get('key') or 'C'
+        if key not in SCALE:
+            flash("Invalid key selected. Please choose a valid key.")
+            return render_template('index.html', scale=sorted(SCALE.keys()))
+
         bpm = int(request.form.get('bpm') or 120)
         timesig = request.form.get('timesig') or '4/4'
         notes = int(request.form.get('notes') or 16)

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -82,3 +82,20 @@ def test_negative_numerator_flash():
     )
     assert b"Time signature must be" in resp.data
 
+
+def test_invalid_key_flash():
+    client = app.test_client()
+    resp = client.post(
+        "/",
+        data={
+            "key": "InvalidKey",
+            "chords": "C",
+            "bpm": "120",
+            "timesig": "4/4",
+            "notes": "8",
+            "motif_length": "4",
+        },
+    )
+    assert resp.status_code == 200
+    assert b"Invalid key selected" in resp.data
+


### PR DESCRIPTION
## Summary
- validate that selected key exists in SCALE in web GUI
- return the index page with a flash message when the key is invalid
- test invalid key flash message in the web interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847669d31fc8321a7090d74738e98a6