### PR TITLE
Add motif length validation

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -679,6 +679,9 @@ def run_cli() -> None:
     if args.motif_length <= 0:
         logging.error("Motif length must be a positive integer.")
         sys.exit(1)
+    if args.motif_length > args.notes:
+        logging.error("Motif length cannot exceed the number of notes.")
+        sys.exit(1)
 
     # Validate key and chord progression.
     if args.key not in SCALE:

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -268,6 +268,13 @@ class MelodyGeneratorGUI:
             )
             return
 
+        if motif_length > notes_count:
+            messagebox.showerror(
+                "Input Error",
+                "Motif length cannot exceed the number of notes."
+            )
+            return
+
         output_file = filedialog.asksaveasfilename(defaultextension=".mid", filetypes=[("MIDI files", "*.mid")])
         if output_file:
             melody = self.generate_melody(key, notes_count, chord_progression, motif_length=motif_length)

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -90,6 +90,10 @@ def index():
                 "Time signature must be two integers in the form 'numerator/denominator' with numerator > 0 and denominator > 0."
             )
             return render_template('index.html', scale=sorted(SCALE.keys()))
+
+        if motif_length > notes:
+            flash("Motif length cannot exceed the number of notes.")
+            return render_template('index.html', scale=sorted(SCALE.keys()))
         melody = generate_melody(key, notes, chords, motif_length=motif_length)
         rhythm = generate_random_rhythm_pattern() if random_rhythm else None
         extra: List[List[str]] = []

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -295,6 +295,42 @@ def test_generate_button_click_invalid_numerator(tmp_path, monkeypatch):
     assert errs
 
 
+def test_generate_button_click_motif_exceeds_notes(tmp_path, monkeypatch):
+    mod, gui_mod, _ = load_module()
+    gui = gui_mod.MelodyGeneratorGUI.__new__(gui_mod.MelodyGeneratorGUI)
+    gui.generate_melody = lambda *a, **k: []
+    gui.create_midi_file = lambda *a, **k: None
+    gui.harmony_line_fn = None
+    gui.counterpoint_fn = None
+    gui.save_settings = None
+    gui.rhythm_pattern = None
+    gui.key_var = types.SimpleNamespace(get=lambda: "C")
+    gui.bpm_var = types.SimpleNamespace(get=lambda: 120)
+    gui.timesig_var = types.SimpleNamespace(get=lambda: "4/4")
+    gui.notes_var = types.SimpleNamespace(get=lambda: 2)
+    gui.motif_entry = types.SimpleNamespace(get=lambda: "4")
+    gui.harmony_var = types.SimpleNamespace(get=lambda: False)
+    gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
+    gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
+    lb = types.SimpleNamespace(curselection=lambda: (0,), get=lambda idx: "C")
+    gui.chord_listbox = lb
+
+    monkeypatch.setattr(
+        gui_mod.filedialog,
+        "asksaveasfilename",
+        lambda **k: str(tmp_path / "x.mid"),
+        raising=False,
+    )
+    errs = []
+    monkeypatch.setattr(
+        gui_mod.messagebox, "showerror", lambda *a, **k: errs.append(a), raising=False
+    )
+
+    gui._generate_button_click()
+
+    assert errs
+
+
 def test_cli_invalid_timesig_exits(tmp_path):
     mod, _, _ = load_module()
     out = tmp_path / "bad.mid"
@@ -362,6 +398,33 @@ def test_cli_non_positive_values_exit(tmp_path):
         "-1",
         "--motif_length",
         "0",
+        "--output",
+        str(out),
+    ]
+    old = sys.argv
+    sys.argv = argv
+    with pytest.raises(SystemExit):
+        mod.run_cli()
+    sys.argv = old
+
+
+def test_cli_motif_exceeds_notes_exit(tmp_path):
+    mod, _, _ = load_module()
+    out = tmp_path / "bad.mid"
+    argv = [
+        "prog",
+        "--key",
+        "C",
+        "--chords",
+        "C,G",
+        "--bpm",
+        "120",
+        "--timesig",
+        "4/4",
+        "--notes",
+        "2",
+        "--motif_length",
+        "4",
         "--output",
         str(out),
     ]

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -99,3 +99,19 @@ def test_invalid_key_flash():
     assert resp.status_code == 200
     assert b"Invalid key selected" in resp.data
 
+
+def test_motif_exceeds_notes_flash():
+    client = app.test_client()
+    resp = client.post(
+        "/",
+        data={
+            "key": "C",
+            "chords": "C",
+            "bpm": "120",
+            "timesig": "4/4",
+            "notes": "2",
+            "motif_length": "4",
+        },
+    )
+    assert b"Motif length cannot exceed" in resp.data
+


### PR DESCRIPTION
## Summary
- check motif length does not exceed note count in GUI, web GUI and CLI
- test handling in each interface

## Testing
- `pytest -q`