### PR TITLE
Add enharmonic chords and validate progressions

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -97,7 +97,7 @@ SCALE = {
     'D': ['D', 'E', 'F#', 'G', 'A', 'B', 'C#'],
     'Eb': ['Eb', 'F', 'G', 'Ab', 'Bb', 'C', 'D'],
     'E': ['E', 'F#', 'G#', 'A', 'B', 'C#', 'D#'],
-    'F': ['F', 'G', 'A', 'A#', 'C', 'D', 'E'],
+    'F': ['F', 'G', 'A', 'Bb', 'C', 'D', 'E'],
     'F#': ['F#', 'G#', 'A#', 'B', 'C#', 'D#', 'E#'],
     'G': ['G', 'A', 'B', 'C', 'D', 'E', 'F#'],
     'Ab': ['Ab', 'Bb', 'C', 'Db', 'Eb', 'F', 'G'],
@@ -176,12 +176,18 @@ CHORDS = {
     "Gm": ["G", "Bb", "D"],
     "G#": ["G#", "B#", "D#"],
     "G#m": ["G#", "B", "D#"],
+    "Ab": ["Ab", "C", "Eb"],
+    "Abm": ["Ab", "Cb", "Eb"],
     "A": ["A", "C#", "E"],
+    "A#": ["A#", "D", "F"],
+    "A#m": ["A#", "C#", "F"],
     "Am": ["A", "C", "E"],
     "Bb": ["Bb", "D", "F"],
     "Bbm": ["Bb", "Db", "F"],
     "B": ["B", "D#", "F#"],
-    "Bm": ["B", "D", "F#"]
+    "Bm": ["B", "D", "F#"],
+    "Db": ["Db", "F", "Ab"],
+    "Dbm": ["Db", "E", "Ab"]
 }
 
 # ``PATTERNS`` stores common rhythmic figures. Each inner list represents a
@@ -239,6 +245,17 @@ def generate_random_chord_progression(key: str, length: int = 4) -> List[str]:
         # Look up the chord quality for this scale degree (major, minor or diminished)
         quality = qualities[idx % len(qualities)]
         chord = note + (quality if quality != 'dim' else '')
+        if chord not in CHORDS:
+            # Translate enharmonic spellings to match available chord names
+            translation = {
+                'A#': 'Bb',
+                'A#m': 'Bbm',
+                'Db': 'C#',
+                'Dbm': 'C#m',
+                'Ab': 'G#',
+                'Abm': 'G#m',
+            }
+            chord = translation.get(chord, chord)
         return chord if chord in CHORDS else random.choice(list(CHORDS.keys()))
 
     # Convert degree numbers to concrete chord names

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -98,3 +98,9 @@ def test_extra_tracks_shorter_line(tmp_path):
     assert len(mid.tracks) == 1 + 2
     assert len(mid.tracks[1]) == 2 * len(harmony)
     assert len(mid.tracks[2]) == 2 * len(cp)
+
+
+def test_progression_chords_exist():
+    for key in ["F", "Ab"]:
+        prog = melody_generator.generate_random_chord_progression(key, 4)
+        assert all(ch in melody_generator.CHORDS for ch in prog)


### PR DESCRIPTION
## Summary
- include flats in the F major scale
- provide enharmonic chord names like Ab, Db and A#
- map mismatched chord spellings to existing names
- test that progressions in F and Ab only produce valid chords

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d1d5c8e8832194b00ac42c6c9e52