### PR TITLE
Improve Flask secret key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ python -m melody_generator.web_gui
 1. Open `http://localhost:5000` in your browser.
 2. Fill out the form just like the GUI version.
 3. Submit to preview and download the generated file.
-4. Set the `FLASK_SECRET` environment variable to override the default Flask
-   session key.
+4. Set the `FLASK_SECRET` environment variable to a persistent secret. If it
+   is not provided a random key is generated on startup and a warning is
+   logged.
 
 
 ## Docker Usage

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -18,6 +18,8 @@ from typing import List
 from flask import Flask, render_template, request, flash
 import base64
 import os
+import secrets
+import logging
 
 # Import the core melody generation package dynamically so the
 # Flask app can live in a separate module without circular imports.
@@ -37,8 +39,18 @@ generate_counterpoint_melody = melody_generator.generate_counterpoint_melody
 
 # Create the Flask application instance and register templates and static files.
 app = Flask(__name__, template_folder="templates", static_folder="static")
-# Allow overriding the session secret via the environment for production use.
-app.secret_key = os.environ.get("FLASK_SECRET", "change-me")
+
+logger = logging.getLogger(__name__)
+
+# Configure the session secret.
+secret = os.environ.get("FLASK_SECRET")
+if not secret:
+    secret = secrets.token_urlsafe(32)
+    logger.warning(
+        "FLASK_SECRET environment variable not set. "
+        "Using a randomly generated key; sessions will not persist across restarts."
+    )
+app.secret_key = secret
 
 
 @app.route('/', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- generate a secure secret key for the Flask app
- log a warning if `FLASK_SECRET` isn't provided
- document secret key behaviour in the Web Interface instructions

## Testing
- `pytest -q`