### PR TITLE
Add env option for settings path

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ pip install melody-generator
 User preferences such as BPM and key are stored in a JSON file located at
 `~/.melody_generator_settings.json`. The GUI loads this file on startup and you
 can choose to save your current selections after generating a melody.
+You can override the location by setting the `MELODY_SETTINGS_FILE` environment
+variable before starting the application.
 
 # Usage
 

--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -24,11 +24,16 @@ from importlib import import_module
 import json
 from pathlib import Path
 from typing import List, Tuple, Optional
+import os
 
 # Default path for storing user preferences
 # The file lives in the user's home directory so settings persist
 # between runs of the application.
-DEFAULT_SETTINGS_FILE = Path.home() / ".melody_generator_settings.json"
+env_path = os.environ.get("MELODY_SETTINGS_FILE")
+if env_path:
+    DEFAULT_SETTINGS_FILE = Path(env_path).expanduser()
+else:
+    DEFAULT_SETTINGS_FILE = Path.home() / ".melody_generator_settings.json"
 
 
 def load_settings(path: Path = DEFAULT_SETTINGS_FILE) -> dict:


### PR DESCRIPTION
## Summary
- allow overriding settings file path through `MELODY_SETTINGS_FILE`
- document the new environment variable in *Settings*

## Testing
- `pytest -q`