### PR TITLE
Exclude tests from package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ addopts = "-vv"
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+exclude = ["tests*"]
+
 [project]
 name = "melody-generator"
 version = "0.1.0"


### PR DESCRIPTION
## Summary
- add a `tool.setuptools.packages.find` section to ignore `tests*`

## Testing
- `python -m build`
- `unzip -l dist/melody_generator-0.1.0-py3-none-any.whl`

------
https://chatgpt.com/codex/tasks/task_e_6848e0e50bcc832189254630dae64615