### PR TITLE
Fix pyproject classifier for new setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Summary
- remove deprecated MIT license classifier from `pyproject.toml`

## Testing
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_6848ebf7dc148321881bf069ddd5b1a9