### PR TITLE
Allow custom MIDI player on all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ User preferences such as BPM and key are stored in a JSON file located at
 can choose to save your current selections after generating a melody.
 You can override the location by setting the `MELODY_SETTINGS_FILE` environment
 variable before starting the application.
+Set the `MELODY_PLAYER` environment variable to a MIDI-capable application if the default player cannot handle `.mid` files. For example, `export MELODY_PLAYER=Music` on macOS or `set MELODY_PLAYER="C:\\Program Files\\Windows Media Player\\wmplayer.exe"` on Windows. The GUI's preview feature will then open files in that player instead of the system default.
 
 # Usage
 

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -407,10 +407,17 @@ class MelodyGeneratorGUI:
             extra_tracks=extra,
         )
         try:
+            player = os.environ.get("MELODY_PLAYER")
             if sys.platform.startswith("win"):
-                os.startfile(tmp_path)  # type: ignore[attr-defined]
+                if player:
+                    subprocess.Popen([player, tmp_path])
+                else:
+                    os.startfile(tmp_path)  # type: ignore[attr-defined]
             elif sys.platform == "darwin":
-                subprocess.Popen(["open", tmp_path])
+                if player:
+                    subprocess.Popen(["open", "-a", player, tmp_path])
+                else:
+                    subprocess.Popen(["open", tmp_path])
             else:
                 subprocess.Popen(["xdg-open", tmp_path])
         except Exception as exc:


### PR DESCRIPTION
## Summary
- open preview files with MELODY_PLAYER on Windows too
- document how to set MELODY_PLAYER on both macOS and Windows

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849e518fb908321bc90bd53d434f9a4