### PR TITLE
Add base octave parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ and use the web interface without installing Python locally.
 - **Number of notes**: Set how many notes to generate with the slider.
 - **Harmony**: Tick this option to add a simple harmony line.
 - **Counterpoint**: Generates an additional melody that moves against the main line.
-- **Base Octave**: Starting octave for the melody. Notes typically stay
+- **Base Octave**: Starting octave for the melody. Use the slider or
+  `--base-octave` flag to shift the register. Notes typically stay
   between this octave and the next higher one with rare octave shifts at
   phrase boundaries.
 
@@ -118,6 +119,7 @@ When running from the command line you can supply optional flags:
 - `--harmony` adds a parallel harmony track.
 - `--harmony-lines N` creates `N` additional harmony parts.
 - `--counterpoint` generates a contrapuntal line based on the melody.
+- `--base-octave N` sets the starting octave of the melody (default: 4).
 
 ## Development
 

--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -887,6 +887,8 @@ def run_cli() -> None:
     parser.add_argument('--counterpoint', action='store_true', help="Generate a counterpoint line.")
     parser.add_argument('--harmony-lines', type=int, default=0, metavar='N',
                         help="Number of harmony lines to add in parallel")
+    parser.add_argument('--base-octave', type=int, default=4,
+                        help="Starting octave for the melody (default: 4).")
     # Parse the provided CLI arguments
     args = parser.parse_args()
 
@@ -937,7 +939,13 @@ def run_cli() -> None:
         )
         sys.exit(1)
 
-    melody = generate_melody(args.key, args.notes, chord_progression, motif_length=args.motif_length)
+    melody = generate_melody(
+        args.key,
+        args.notes,
+        chord_progression,
+        motif_length=args.motif_length,
+        base_octave=args.base_octave,
+    )
     rhythm = generate_random_rhythm_pattern() if args.random_rhythm else None
     # Collect additional harmony tracks requested on the command line
     extra: List[List[str]] = []

--- a/melody_generator/templates/index.html
+++ b/melody_generator/templates/index.html
@@ -29,6 +29,7 @@
     BPM: <input type="number" name="bpm" value="120"><br>
     Time Signature: <input name="timesig" value="4/4"><br>
     Number of notes: <input type="number" name="notes" value="16"><br>
+    Base octave: <input type="number" name="base_octave" value="4"><br>
     Motif length: <input type="number" name="motif_length" value="4"><br>
     <label><input type="checkbox" name="harmony" value="1"> Harmony</label><br>
     Counterpoint: <input type="checkbox" name="counterpoint" value="1"><br>

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -75,6 +75,7 @@ def index():
         timesig = request.form.get('timesig') or '4/4'
         notes = int(request.form.get('notes') or 16)
         motif_length = int(request.form.get('motif_length') or 4)
+        base_octave = int(request.form.get('base_octave') or 4)
         harmony = bool(request.form.get('harmony'))
         random_rhythm = bool(request.form.get('random_rhythm'))
         counterpoint = bool(request.form.get('counterpoint'))
@@ -111,7 +112,13 @@ def index():
         if motif_length > notes:
             flash("Motif length cannot exceed the number of notes.")
             return render_template('index.html', scale=sorted(SCALE.keys()))
-        melody = generate_melody(key, notes, chords, motif_length=motif_length)
+        melody = generate_melody(
+            key,
+            notes,
+            chords,
+            motif_length=motif_length,
+            base_octave=base_octave,
+        )
         rhythm = generate_random_rhythm_pattern() if random_rhythm else None
         extra: List[List[str]] = []
         for _ in range(max(0, harmony_lines)):

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -125,6 +125,8 @@ def test_cli_subprocess_creates_file(tmp_path):
             "4/4",
             "--notes",
             "8",
+            "--base-octave",
+            "4",
             "--output",
             str(output),
         ],
@@ -139,7 +141,8 @@ def test_generate_button_click(tmp_path, monkeypatch):
     out = tmp_path / "gui.mid"
     calls = {}
 
-    def gen_mel(key, notes, chords, motif_length=4):
+    def gen_mel(key, notes, chords, motif_length=4, base_octave=4):
+        calls["oct"] = base_octave
         return ["C4"] * notes
 
     def create(mel, bpm, ts, path, harmony=False, pattern=None, extra_tracks=None):
@@ -165,6 +168,7 @@ def test_generate_button_click(tmp_path, monkeypatch):
     gui.timesig_var = types.SimpleNamespace(get=lambda: "4/4")
     gui.notes_var = types.SimpleNamespace(get=lambda: 4)
     gui.motif_entry = types.SimpleNamespace(get=lambda: "2")
+    gui.base_octave_var = types.SimpleNamespace(get=lambda: 5)
     gui.harmony_var = types.SimpleNamespace(get=lambda: True)
     gui.counterpoint_var = types.SimpleNamespace(get=lambda: True)
     gui.harmony_lines = types.SimpleNamespace(get=lambda: "1")
@@ -209,6 +213,7 @@ def test_generate_button_click(tmp_path, monkeypatch):
     assert infos
     assert calls["args"][3] == str(out)
     assert len(calls["args"][6]) == 2
+    assert calls["oct"] == 5
 
 
 def test_generate_button_click_non_positive(tmp_path, monkeypatch):
@@ -225,6 +230,7 @@ def test_generate_button_click_non_positive(tmp_path, monkeypatch):
     gui.timesig_var = types.SimpleNamespace(get=lambda: "4/4")
     gui.notes_var = types.SimpleNamespace(get=lambda: -1)
     gui.motif_entry = types.SimpleNamespace(get=lambda: "0")
+    gui.base_octave_var = types.SimpleNamespace(get=lambda: 4)
     gui.harmony_var = types.SimpleNamespace(get=lambda: False)
     gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
     gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
@@ -254,6 +260,7 @@ def test_generate_button_click_invalid_denominator(tmp_path, monkeypatch):
     gui.timesig_var = types.SimpleNamespace(get=lambda: "4/0")
     gui.notes_var = types.SimpleNamespace(get=lambda: 4)
     gui.motif_entry = types.SimpleNamespace(get=lambda: "2")
+    gui.base_octave_var = types.SimpleNamespace(get=lambda: 4)
     gui.harmony_var = types.SimpleNamespace(get=lambda: False)
     gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
     gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
@@ -290,6 +297,7 @@ def test_generate_button_click_invalid_numerator(tmp_path, monkeypatch):
     gui.timesig_var = types.SimpleNamespace(get=lambda: "0/4")
     gui.notes_var = types.SimpleNamespace(get=lambda: 4)
     gui.motif_entry = types.SimpleNamespace(get=lambda: "2")
+    gui.base_octave_var = types.SimpleNamespace(get=lambda: 4)
     gui.harmony_var = types.SimpleNamespace(get=lambda: False)
     gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
     gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
@@ -326,6 +334,7 @@ def test_generate_button_click_motif_exceeds_notes(tmp_path, monkeypatch):
     gui.timesig_var = types.SimpleNamespace(get=lambda: "4/4")
     gui.notes_var = types.SimpleNamespace(get=lambda: 2)
     gui.motif_entry = types.SimpleNamespace(get=lambda: "4")
+    gui.base_octave_var = types.SimpleNamespace(get=lambda: 4)
     gui.harmony_var = types.SimpleNamespace(get=lambda: False)
     gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
     gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
@@ -363,6 +372,8 @@ def test_cli_invalid_timesig_exits(tmp_path):
         "4",  # missing denominator
         "--notes",
         "8",
+        "--base-octave",
+        "4",
         "--output",
         str(out),
     ]
@@ -388,6 +399,8 @@ def test_cli_invalid_numerator_exits(tmp_path):
         "0/4",
         "--notes",
         "8",
+        "--base-octave",
+        "4",
         "--output",
         str(out),
     ]
@@ -415,6 +428,8 @@ def test_cli_non_positive_values_exit(tmp_path):
         "-1",
         "--motif_length",
         "0",
+        "--base-octave",
+        "4",
         "--output",
         str(out),
     ]
@@ -441,6 +456,8 @@ def test_cli_motif_exceeds_notes_exit(tmp_path):
         "--notes",
         "2",
         "--motif_length",
+        "4",
+        "--base-octave",
         "4",
         "--output",
         str(out),

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -55,6 +55,7 @@ def test_invalid_timesig_flash():
             "timesig": "4",  # invalid
             "notes": "8",
             "motif_length": "4",
+            "base_octave": "4",
         },
     )
     assert b"Time signature must be" in resp.data
@@ -71,6 +72,7 @@ def test_invalid_numerator_flash():
             "timesig": "0/4",
             "notes": "8",
             "motif_length": "4",
+            "base_octave": "4",
         },
     )
     assert b"Time signature must be" in resp.data
@@ -87,6 +89,7 @@ def test_negative_numerator_flash():
             "timesig": "-3/4",
             "notes": "8",
             "motif_length": "4",
+            "base_octave": "4",
         },
     )
     assert b"Time signature must be" in resp.data
@@ -103,6 +106,7 @@ def test_invalid_key_flash():
             "timesig": "4/4",
             "notes": "8",
             "motif_length": "4",
+            "base_octave": "4",
         },
     )
     assert resp.status_code == 200
@@ -120,6 +124,7 @@ def test_motif_exceeds_notes_flash():
             "timesig": "4/4",
             "notes": "2",
             "motif_length": "4",
+            "base_octave": "4",
         },
     )
     assert b"Motif length cannot exceed" in resp.data
@@ -136,6 +141,7 @@ def test_invalid_chord_flash():
             "timesig": "4/4",
             "notes": "8",
             "motif_length": "4",
+            "base_octave": "4",
         },
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- support --base-octave in CLI
- expose Base Octave slider in the Tk GUI
- plumb base_octave through web interface
- document the new argument in README
- adjust tests for base octave coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3b22105883219e0dd734bb84e2f0