### PR TITLE
Add chord progression MIDI feature

### DIFF
--- a/melody_generator/templates/index.html
+++ b/melody_generator/templates/index.html
@@ -34,6 +34,8 @@
     <label><input type="checkbox" name="harmony" value="1"> Harmony</label><br>
     Counterpoint: <input type="checkbox" name="counterpoint" value="1"><br>
     Harmony lines: <input type="number" name="harmony_lines" value="0"><br>
+    <label><input type="checkbox" name="include_chords" value="1"> Include chord track</label><br>
+    <label><input type="checkbox" name="chords_same" value="1"> Merge chords with melody</label><br>
     <label><input type="checkbox" name="random_rhythm" value="1"> Random rhythm</label><br>
     <input type="submit" value="Generate">
   </form>

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -80,6 +80,8 @@ def index():
         random_rhythm = bool(request.form.get('random_rhythm'))
         counterpoint = bool(request.form.get('counterpoint'))
         harmony_lines = int(request.form.get('harmony_lines') or 0)
+        include_chords = bool(request.form.get('include_chords'))
+        chords_same = bool(request.form.get('chords_same'))
 
         # Determine the chord progression. The user may provide one
         # manually or tick the "random" box to generate it.
@@ -148,6 +150,8 @@ def index():
             harmony=harmony,
             pattern=rhythm,
             extra_tracks=extra,
+            chord_progression=chords if include_chords else None,
+            chords_separate=not chords_same,
         )
 
         # Read the generated MIDI data back into memory then delete the

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -127,6 +127,7 @@ def test_cli_subprocess_creates_file(tmp_path):
             "8",
             "--base-octave",
             "4",
+            "--include-chords",
             "--output",
             str(output),
         ],
@@ -145,7 +146,7 @@ def test_generate_button_click(tmp_path, monkeypatch):
         calls["oct"] = base_octave
         return ["C4"] * notes
 
-    def create(mel, bpm, ts, path, harmony=False, pattern=None, extra_tracks=None):
+    def create(mel, bpm, ts, path, harmony=False, pattern=None, extra_tracks=None, **kw):
         calls["args"] = (mel, bpm, ts, path, harmony, pattern, extra_tracks)
         with open(path, "w", encoding="utf-8") as fh:
             fh.write("midi")
@@ -172,6 +173,8 @@ def test_generate_button_click(tmp_path, monkeypatch):
     gui.harmony_var = types.SimpleNamespace(get=lambda: True)
     gui.counterpoint_var = types.SimpleNamespace(get=lambda: True)
     gui.harmony_lines = types.SimpleNamespace(get=lambda: "1")
+    gui.include_chords_var = types.SimpleNamespace(get=lambda: True)
+    gui.chords_same_var = types.SimpleNamespace(get=lambda: False)
     lb = types.SimpleNamespace(
         curselection=lambda: (0, 1),
         get=lambda idx: ["C", "G"][idx],
@@ -234,6 +237,8 @@ def test_generate_button_click_non_positive(tmp_path, monkeypatch):
     gui.harmony_var = types.SimpleNamespace(get=lambda: False)
     gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
     gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
+    gui.include_chords_var = types.SimpleNamespace(get=lambda: False)
+    gui.chords_same_var = types.SimpleNamespace(get=lambda: False)
     lb = types.SimpleNamespace(curselection=lambda: (0,), get=lambda idx: "C")
     gui.chord_listbox = lb
 

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import types
 import importlib
 import pytest
+import random
 
 # Provide a minimal stub for the 'mido' module so the import succeeds
 stub_mido = types.ModuleType("mido")
@@ -100,6 +101,43 @@ def test_extra_tracks_shorter_line(tmp_path):
     assert len(mid.tracks[2]) == 2 * len(cp)
 
 
+def test_chord_track_added(tmp_path):
+    chords = ["C", "G"]
+    melody = generate_melody("C", 4, chords, motif_length=4)
+    out = tmp_path / "ch.mid"
+    create_midi_file(
+        melody,
+        120,
+        (4, 4),
+        str(out),
+        harmony=False,
+        pattern=[0.25],
+        chord_progression=chords,
+    )
+    mid = DummyMidiFile.last_instance
+    assert mid is not None
+    assert len(mid.tracks) == 2
+
+
+def test_chords_on_same_track(tmp_path):
+    chords = ["C", "G"]
+    melody = generate_melody("C", 4, chords, motif_length=4)
+    out = tmp_path / "merge.mid"
+    create_midi_file(
+        melody,
+        120,
+        (4, 4),
+        str(out),
+        harmony=False,
+        pattern=[0.25],
+        chord_progression=chords,
+        chords_separate=False,
+    )
+    mid = DummyMidiFile.last_instance
+    assert mid is not None
+    assert len(mid.tracks) == 1
+
+
 def test_rest_values_in_pattern(tmp_path):
     chords = ["C", "G", "Am", "F"]
     melody = generate_melody("C", 4, chords, motif_length=4)
@@ -134,6 +172,7 @@ def test_diatonic_chords_major_minor():
 
 def test_melody_trends_up_then_down():
     chords = ["C", "G", "Am", "F"]
+    random.seed(0)
     mel = generate_melody("C", 12, chords, motif_length=4)
     midi_vals = [note_to_midi(n) for n in mel]
     mid = len(midi_vals) // 2

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -147,3 +147,22 @@ def test_invalid_chord_flash():
     assert resp.status_code == 200
     assert b"Unknown chord" in resp.data
 
+
+def test_include_chords_flag():
+    client = app.test_client()
+    resp = client.post(
+        "/",
+        data={
+            "key": "C",
+            "chords": "C",
+            "bpm": "120",
+            "timesig": "4/4",
+            "notes": "8",
+            "motif_length": "4",
+            "base_octave": "4",
+            "include_chords": "1",
+            "chords_same": "1",
+        },
+    )
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- allow create_midi_file to render chord progressions
- expose new CLI options to include chords in the output
- update GUI and web GUI with checkboxes for chord tracks
- handle new flags in tests and add tests for chord MIDI

## Testing
- `ruff check .`
- `pytest -q`