### PR TITLE
Add time signature validation

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -510,8 +510,8 @@ def generate_melody(
     if pattern is None:
         pattern = random.choice(PATTERNS)
 
-    if time_signature[1] <= 0:
-        raise ValueError("time_signature denominator must be greater than 0")
+    if time_signature[0] <= 0 or time_signature[1] <= 0:
+        raise ValueError("time_signature elements must be greater than 0")
     beat_unit = 1 / time_signature[1]
     start_beat = 0.0
 
@@ -781,6 +781,8 @@ def create_midi_file(
         chords_separate: When ``True`` chords are written to a new track,
             otherwise they are merged with the melody track.
     """
+    if time_signature[0] <= 0 or time_signature[1] <= 0:
+        raise ValueError("time_signature elements must be greater than 0")
     ticks_per_beat = 480
     mid = MidiFile(ticks_per_beat=ticks_per_beat)
     track = MidiTrack()

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -65,6 +65,25 @@ def test_generate_melody_invalid_denominator():
         generate_melody('C', 4, chords, motif_length=4, time_signature=(4, 0))
 
 
+def test_generate_melody_invalid_numerator_and_negative_denominator():
+    chords = ['C', 'G']
+    with pytest.raises(ValueError):
+        generate_melody('C', 4, chords, motif_length=4, time_signature=(0, 4))
+    with pytest.raises(ValueError):
+        generate_melody('C', 4, chords, motif_length=4, time_signature=(4, -1))
+
+
+def test_create_midi_file_invalid_time_signature(tmp_path):
+    melody = ['C4'] * 4
+    out = tmp_path / 'bad.mid'
+    with pytest.raises(ValueError):
+        create_midi_file(melody, 120, (0, 4), str(out))
+    with pytest.raises(ValueError):
+        create_midi_file(melody, 120, (4, 0), str(out))
+    with pytest.raises(ValueError):
+        create_midi_file(melody, 120, (4, -3), str(out))
+
+
 def test_extra_tracks_created(tmp_path):
     chords = ['C', 'G', 'Am', 'F']
     melody = generate_melody('C', 8, chords, motif_length=4)


### PR DESCRIPTION
## Summary
- validate numerator and denominator in `generate_melody`
- validate numerator and denominator in `create_midi_file`
- test invalid time signatures for melody generation and MIDI output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1c19d7b883218fac15797099d323