### PR TITLE
Implement harmony reflection for negative intervals

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -702,14 +702,14 @@ def generate_harmony_line(melody: List[str], interval: int = 4) -> List[str]:
     """
     harmony = []
     for note in melody:
-        # Shift each melody note by the specified interval while clamping the
-        # value so it stays within the valid MIDI range (0-127).  When the shift
-        # would exceed the range, move in the opposite direction to keep the
-        # harmony line usable.
         base = note_to_midi(note)
-        direction = -1 if base + interval > 120 else 1
-        midi_val = max(0, min(127, base + direction * interval))
-        harmony.append(midi_to_note(midi_val))
+        target = base + interval
+        # Reflect intervals that fall outside the MIDI range back toward
+        # the melody so the resulting notes stay valid.
+        if target < 0 or target > 127:
+            target = base - interval
+        target = max(0, min(127, target))
+        harmony.append(midi_to_note(target))
     return harmony
 
 

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -126,6 +126,15 @@ def test_harmony_and_counterpoint_intervals_and_tracks(tmp_path):
     assert mid is not None and len(mid.tracks) == 1 + 1 + 2
 
 
+def test_negative_interval_harmony():
+    """Harmony lines with negative intervals drop below the melody."""
+    mod, _, _ = load_module()
+    melody = ["G4", "A4", "B4"]
+    harmony = mod.generate_harmony_line(melody, interval=-3)
+    for m, h in zip(melody, harmony):
+        assert mod.note_to_midi(h) - mod.note_to_midi(m) == -3
+
+
 def test_cli_subprocess_creates_file(tmp_path):
     """Run the CLI entry point in a real subprocess.
 


### PR DESCRIPTION
## Summary
- reflect notes outside the MIDI range back into bounds when generating harmony
- test dropping harmony by a negative interval

## Testing
- `ruff check .`
- `pytest -q`