### PR TITLE
Install FluidSynth in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,28 @@
 FROM python:3.11-slim
 
+# ---------------------------------------------------------------------------
+# Melody Generator container image
+# ---------------------------------------------------------------------------
+#
+# The application previews generated melodies using the ``fluidsynth`` CLI.
+# Install the system packages here so the web interface can render audio in
+# the container.  ``fluid-soundfont-gm`` provides a basic SoundFont so users
+# do not have to supply their own.
+# ---------------------------------------------------------------------------
+
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+
+# Install the Python dependencies and the system packages required for audio
+# rendering.  ``fluid-soundfont-gm`` is optional but ensures preview works
+# without additional configuration.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        fluidsynth \
+        fluid-soundfont-gm \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- add `apt-get` step to install FluidSynth and a default soundfont
- keep apt cache clean

## Testing
- `pytest -q`
- `docker build -t melody-generator .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d90e52530832190f7861283e18fbb