### PR TITLE
Improve playback error handling

### DIFF
--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -16,6 +16,10 @@ import sys
 from tempfile import NamedTemporaryFile
 
 from . import diatonic_chords
+# ``MidiPlaybackError`` signals that preview playback failed within the
+# ``playback`` helper module. Catching it allows the GUI to fall back to the
+# system default player without masking unrelated errors.
+from .playback import MidiPlaybackError
 
 # Mapping of display names to General MIDI program numbers used by the
 # instrument selector. Only a small subset is provided for demonstration
@@ -554,9 +558,10 @@ class MelodyGeneratorGUI:
         try:
             from . import playback
             playback.play_midi(tmp_path)
-        except Exception:
-            # Fall back to the system registered MIDI player when FluidSynth
-            # is unavailable or fails to initialize.
+        except MidiPlaybackError:
+            # Playback errors are expected when FluidSynth is missing or fails
+            # to initialize. In that case fall back to the user's default MIDI
+            # player so preview still works.
             self._open_default_player(tmp_path)
 
     def _open_default_player(self, path: str) -> None:

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -15,6 +15,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 
 from melody_generator import playback
+from melody_generator.playback import MidiPlaybackError
 
 from flask import Flask, render_template, request, flash
 import base64
@@ -177,7 +178,10 @@ def index():
 
         try:
             playback.render_midi_to_wav(tmp_path, wav_path)
-        except Exception:
+        except MidiPlaybackError:
+            # Rendering failures occur when FluidSynth or a compatible soundfont
+            # is unavailable. In that scenario the browser will receive the MIDI
+            # data without a WAV preview.
             wav_data = None
         else:
             with open(wav_path, 'rb') as fh:

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -600,6 +600,47 @@ def test_preview_button_uses_playback(monkeypatch, tmp_path):
     assert "path" in calls
 
 
+def test_preview_button_falls_back(monkeypatch, tmp_path):
+    """Playback errors should trigger the fallback player."""
+
+    mod, gui_mod, _ = load_module()
+
+    gui = gui_mod.MelodyGeneratorGUI.__new__(gui_mod.MelodyGeneratorGUI)
+    gui.generate_melody = lambda *a, **k: ["C4"] * 4
+    gui.create_midi_file = lambda *a, **k: Path(a[3]).write_text("midi")
+    gui.harmony_line_fn = None
+    gui.counterpoint_fn = None
+    gui.save_settings = None
+    gui.rhythm_pattern = None
+    gui.key_var = types.SimpleNamespace(get=lambda: "C")
+    gui.bpm_var = types.SimpleNamespace(get=lambda: 120)
+    gui.timesig_var = types.SimpleNamespace(get=lambda: "4/4")
+    gui.notes_var = types.SimpleNamespace(get=lambda: 4)
+    gui.motif_entry = types.SimpleNamespace(get=lambda: "2")
+    gui.base_octave_var = types.SimpleNamespace(get=lambda: 4)
+    gui.instrument_var = types.SimpleNamespace(get=lambda: "Piano")
+    gui.harmony_var = types.SimpleNamespace(get=lambda: False)
+    gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
+    gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
+    gui.include_chords_var = types.SimpleNamespace(get=lambda: False)
+    gui.chords_same_var = types.SimpleNamespace(get=lambda: False)
+    gui.chord_listbox = types.SimpleNamespace(
+        curselection=lambda: (0,), get=lambda idx: "C"
+    )
+
+    def raise_err(_p):
+        raise gui_mod.MidiPlaybackError("boom")
+
+    stub_play = types.SimpleNamespace(play_midi=raise_err)
+    monkeypatch.setitem(sys.modules, "melody_generator.playback", stub_play)
+    calls = {}
+    monkeypatch.setattr(gui, "_open_default_player", lambda p: calls.setdefault("fallback", p))
+
+    gui._preview_button_click()
+
+    assert "fallback" in calls
+
+
 def test_cli_play_flag_invokes_playback(monkeypatch, tmp_path):
     """Providing ``--play`` should call ``playback.play_midi``."""
 


### PR DESCRIPTION
## Summary
- expose `MidiPlaybackError` in gui modules
- fall back to system player only for `MidiPlaybackError`
- handle rendering failures in `web_gui` with the specific exception
- test GUI preview fallback on playback error

## Testing
- `pytest -q`