### PR TITLE
Improve macOS setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ You can also set up the dependencies manually with:
 ```bash
 pip install -r requirements.txt
 ```
+### Quick setup on macOS
+
+Run the helper script to install Homebrew packages and Python
+dependencies. The script checks for an existing ``python3``
+installation and only installs a new version when the current one is
+older than 3.8. A virtual environment is created under ``./venv``.
+
+```bash
+./setup_mac.sh
+```
+
+After it completes activate the environment with
+`source venv/bin/activate` to start using ``melody-generator``.
 PyFluidSynth wraps the FluidSynth library which must be installed separately.
 Install the system package with `apt-get install fluidsynth` on Debian-based Linux or `brew install fluid-synth` on macOS.
 Without FluidSynth the preview button and web playback will fail.

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------------------
+# setup_mac.sh - Environment setup for Melody-Generator on macOS.
+#
+# This helper installs Homebrew packages and Python dependencies needed
+# to run Melody-Generator. It performs version checks so that existing
+# installations are reused when possible.
+#
+# Usage:
+#   ./setup_mac.sh
+#
+# Set the environment variable DRY_RUN=1 to print commands without
+# executing them. The FORCE_MAC=1 variable allows running the script on
+# non-macOS systems (useful for CI testing).
+#----------------------------------------------------------------------
+set -euo pipefail
+
+# run_cmd executes a command or prints it when DRY_RUN is enabled.
+run_cmd() {
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        echo "DRY RUN: $*"
+    else
+        "$@"
+    fi
+}
+
+# verify_mac exits unless running on macOS. The FORCE_MAC variable can
+# override this to facilitate automated testing on Linux containers.
+verify_mac() {
+    if [[ "${FORCE_MAC:-0}" == "1" ]]; then
+        return
+    fi
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        echo "This setup script is intended for macOS." >&2
+        exit 1
+    fi
+}
+
+# check_python ensures Python >=3.8 is installed. If python3 is missing or
+# too old the function installs a newer version using Homebrew.
+check_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        local version
+        version=$(python3 -V 2>&1 | awk '{print $2}')
+        local major minor
+        IFS=. read -r major minor _ <<<"$version"
+        if (( major > 3 || (major == 3 && minor >= 8) )); then
+            echo "Found Python $version"
+            return
+        fi
+        echo "Python $version is too old. Updating via Homebrew..."
+    else
+        echo "Python3 not found. Installing via Homebrew..."
+    fi
+    run_cmd brew install python
+}
+
+# install_brew_pkg installs a Homebrew package only when it is not already
+# present to avoid redundant operations.
+install_brew_pkg() {
+    local pkg=$1
+    if ! brew list "$pkg" >/dev/null 2>&1; then
+        echo "Installing $pkg via Homebrew..."
+        run_cmd brew install "$pkg"
+    else
+        echo "$pkg already installed"
+    fi
+}
+
+main() {
+    verify_mac
+
+    # Homebrew must be installed; abort if missing
+    if ! command -v brew >/dev/null 2>&1; then
+        echo "Homebrew is required but was not found." >&2
+        echo "Install Homebrew from https://brew.sh/ and re-run this script." >&2
+        exit 1
+    fi
+
+    check_python
+    install_brew_pkg fluid-synth
+    install_brew_pkg fluid-soundfont-gm
+
+    if [[ ! -d venv ]]; then
+        echo "Creating Python virtual environment in ./venv"
+        run_cmd python3 -m venv venv
+    fi
+
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        echo "DRY RUN: source venv/bin/activate"
+        echo "DRY RUN: pip install --upgrade pip"
+        echo "DRY RUN: pip install -r requirements.txt"
+        echo "DRY RUN: pip install -e ."
+    else
+        # shellcheck source=/dev/null
+        source venv/bin/activate
+        run_cmd pip install --upgrade pip
+        run_cmd pip install -r requirements.txt
+        run_cmd pip install -e .
+        deactivate
+    fi
+
+    echo "Setup complete. Activate with: source venv/bin/activate"
+}
+
+main "$@"

--- a/tests/test_setup_mac.py
+++ b/tests/test_setup_mac.py
@@ -1,0 +1,52 @@
+import os
+import subprocess
+from pathlib import Path
+
+def test_skip_python_install(tmp_path):
+    """Verify setup script does not attempt to install Python when version is sufficient."""
+    # Create directory for fake executables
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "log.txt"
+
+    # Stub brew: exit code 1 for 'list' to force installation for other packages
+    brew_path = bin_dir / "brew"
+    brew_path.write_text(
+        "#!/bin/bash\nif [ \"$1\" = list ]; then exit 1; fi\necho brew $@ >> '%s'\n" % log_file
+    )
+    brew_path.chmod(0o755)
+
+    # Stub python3 with a modern version and minimal venv support
+    py_path = bin_dir / "python3"
+    py_path.write_text(
+        "#!/bin/bash\n"
+        "if [ \"$1\" = -V ]; then echo 'Python 3.9.1'; exit 0; fi\n"
+        "if [ \"$1\" = -m ] && [ \"$2\" = venv ]; then mkdir -p $3/bin; exit 0; fi\n"
+    )
+    py_path.chmod(0o755)
+
+    # Stub pip so install commands succeed in dry run
+    pip_path = bin_dir / "pip"
+    pip_path.write_text("#!/bin/bash\necho pip $@ >> '%s'\n" % log_file)
+    pip_path.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "FORCE_MAC": "1",
+        "DRY_RUN": "1",
+    })
+
+    result = subprocess.run(
+        ["bash", "setup_mac.sh"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    # The script should not attempt to install python because version >=3.8
+    assert "brew install python" not in result.stdout
+    # But it should attempt to install fluid-synth since brew list fails
+    assert "brew install fluid-synth" in result.stdout


### PR DESCRIPTION
## Summary
- enhance setup script with OS override, version checks, and dry‑run mode
- skip Python install if an adequate version is already present
- document the version checking behavior in the README
- add unit test covering the new logic

## Testing
- `pytest -q`