### PR TITLE
Validate denominators for time signature

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -95,68 +95,67 @@ def save_settings(settings: dict, path: Path = DEFAULT_SETTINGS_FILE) -> None:
 # semitone offset within an octave so that functions like ``note_to_midi``
 # can handle enharmonic notes (e.g. ``Db`` and ``C#``).
 NOTE_TO_SEMITONE = {
-    'C': 0,
-    'B#': 0,
-    'C#': 1,
-    'Db': 1,
-    'D': 2,
-    'D#': 3,
-    'Eb': 3,
-    'E': 4,
-    'Fb': 4,
-    'E#': 5,
-    'F': 5,
-    'F#': 6,
-    'Gb': 6,
-    'G': 7,
-    'G#': 8,
-    'Ab': 8,
-    'A': 9,
-    'A#': 10,
-    'Bb': 10,
-    'B': 11,
-    'Cb': 11,
+    "C": 0,
+    "B#": 0,
+    "C#": 1,
+    "Db": 1,
+    "D": 2,
+    "D#": 3,
+    "Eb": 3,
+    "E": 4,
+    "Fb": 4,
+    "E#": 5,
+    "F": 5,
+    "F#": 6,
+    "Gb": 6,
+    "G": 7,
+    "G#": 8,
+    "Ab": 8,
+    "A": 9,
+    "A#": 10,
+    "Bb": 10,
+    "B": 11,
+    "Cb": 11,
 }
 
 # Keep a basic list of note names (using sharps) for any other logic that
 # relies on it.
-NOTES: List[str] = [
-    'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'
-]
+NOTES: List[str] = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
 
 # Map key names to the notes that make up their diatonic scale. Functions that
 # generate melodies or harmonies reference this to stay in the chosen key.
 SCALE = {
-    'C': ['C', 'D', 'E', 'F', 'G', 'A', 'B'],
-    'C#': ['C#', 'D#', 'E#', 'F#', 'G#', 'A#', 'B#'],
-    'D': ['D', 'E', 'F#', 'G', 'A', 'B', 'C#'],
-    'Eb': ['Eb', 'F', 'G', 'Ab', 'Bb', 'C', 'D'],
-    'E': ['E', 'F#', 'G#', 'A', 'B', 'C#', 'D#'],
-    'F': ['F', 'G', 'A', 'Bb', 'C', 'D', 'E'],
-    'F#': ['F#', 'G#', 'A#', 'B', 'C#', 'D#', 'E#'],
-    'G': ['G', 'A', 'B', 'C', 'D', 'E', 'F#'],
-    'Ab': ['Ab', 'Bb', 'C', 'Db', 'Eb', 'F', 'G'],
-    'A': ['A', 'B', 'C#', 'D', 'E', 'F#', 'G#'],
-    'Bb': ['Bb', 'C', 'D', 'Eb', 'F', 'G', 'A'],
-    'B': ['B', 'C#', 'D#', 'E', 'F#', 'G#', 'A#'],
+    "C": ["C", "D", "E", "F", "G", "A", "B"],
+    "C#": ["C#", "D#", "E#", "F#", "G#", "A#", "B#"],
+    "D": ["D", "E", "F#", "G", "A", "B", "C#"],
+    "Eb": ["Eb", "F", "G", "Ab", "Bb", "C", "D"],
+    "E": ["E", "F#", "G#", "A", "B", "C#", "D#"],
+    "F": ["F", "G", "A", "Bb", "C", "D", "E"],
+    "F#": ["F#", "G#", "A#", "B", "C#", "D#", "E#"],
+    "G": ["G", "A", "B", "C", "D", "E", "F#"],
+    "Ab": ["Ab", "Bb", "C", "Db", "Eb", "F", "G"],
+    "A": ["A", "B", "C#", "D", "E", "F#", "G#"],
+    "Bb": ["Bb", "C", "D", "Eb", "F", "G", "A"],
+    "B": ["B", "C#", "D#", "E", "F#", "G#", "A#"],
     # Minor keys
-    'Cm': ['C', 'D', 'Eb', 'F', 'G', 'Ab', 'Bb'],
-    'C#m': ['C#', 'D#', 'E', 'F#', 'G#', 'A', 'B'],
-    'Dm': ['D', 'E', 'F', 'G', 'A', 'Bb', 'C'],
-    'Ebm': ['Eb', 'F', 'Gb', 'Ab', 'Bb', 'Cb', 'Db'],
-    'Em': ['E', 'F#', 'G', 'A', 'B', 'C', 'D'],
-    'Fm': ['F', 'G', 'Ab', 'Bb', 'C', 'Db', 'Eb'],
-    'F#m': ['F#', 'G#', 'A', 'B', 'C#', 'D', 'E'],
-    'Gm': ['G', 'A', 'Bb', 'C', 'D', 'Eb', 'F'],
-    'G#m': ['G#', 'A#', 'B', 'C#', 'D#', 'E', 'F#'],
-    'Am': ['A', 'B', 'C', 'D', 'E', 'F', 'G'],
-    'Bbm': ['Bb', 'C', 'Db', 'Eb', 'F', 'Gb', 'Ab'],
-    'Bm': ['B', 'C#', 'D', 'E', 'F#', 'G', 'A']
+    "Cm": ["C", "D", "Eb", "F", "G", "Ab", "Bb"],
+    "C#m": ["C#", "D#", "E", "F#", "G#", "A", "B"],
+    "Dm": ["D", "E", "F", "G", "A", "Bb", "C"],
+    "Ebm": ["Eb", "F", "Gb", "Ab", "Bb", "Cb", "Db"],
+    "Em": ["E", "F#", "G", "A", "B", "C", "D"],
+    "Fm": ["F", "G", "Ab", "Bb", "C", "Db", "Eb"],
+    "F#m": ["F#", "G#", "A", "B", "C#", "D", "E"],
+    "Gm": ["G", "A", "Bb", "C", "D", "Eb", "F"],
+    "G#m": ["G#", "A#", "B", "C#", "D#", "E", "F#"],
+    "Am": ["A", "B", "C", "D", "E", "F", "G"],
+    "Bbm": ["Bb", "C", "Db", "Eb", "F", "Gb", "Ab"],
+    "Bm": ["B", "C#", "D", "E", "F#", "G", "A"],
 }
 
 # Programmatically extend ``SCALE`` with several common modes and pentatonic
 # scales.  This keeps the list of keys manageable while providing additional
 # variety when generating melodies.
+
 
 def _build_scale(root: str, pattern: List[int]) -> List[str]:
     """Return a scale starting at ``root`` following ``pattern`` intervals.
@@ -226,7 +225,7 @@ CHORDS = {
     "B": ["B", "D#", "F#"],
     "Bm": ["B", "D", "F#"],
     "Db": ["Db", "F", "Ab"],
-    "Dbm": ["Db", "E", "Ab"]
+    "Dbm": ["Db", "E", "Ab"],
 }
 
 # ``PATTERNS`` stores common rhythmic figures. Each inner list represents a
@@ -234,17 +233,17 @@ CHORDS = {
 # creating the MIDI file.
 PATTERNS: List[List[float]] = [
     # Basic march-like rhythm
-    [0.25, 0.25, 0.5],    # quarter, quarter, half
+    [0.25, 0.25, 0.5],  # quarter, quarter, half
     # Simple syncopation with a dotted half
-    [0.25, 0.75],         # quarter, dotted half
+    [0.25, 0.75],  # quarter, dotted half
     # Even half notes
-    [0.5, 0.5],           # half, half
+    [0.5, 0.5],  # half, half
     # Dotted quarter pattern often found in waltzes
     [0.375, 0.375, 0.25],  # dotted quarter, dotted quarter, quarter
     # Eighth-note lead in to a half note
     [0.125, 0.125, 0.25, 0.5],  # two eighths, quarter, half
     # Continuous run of sixteenth notes
-    [0.0625] * 8          # a run of sixteenth notes
+    [0.0625] * 8,  # a run of sixteenth notes
 ]
 
 
@@ -270,7 +269,7 @@ def generate_random_chord_progression(key: str, length: int = 4) -> List[str]:
     if key not in SCALE:
         raise ValueError(f"Unknown key '{key}'")
 
-    is_minor = key.endswith('m')
+    is_minor = key.endswith("m")
     notes = SCALE[key]
     patterns = minor_patterns if is_minor else major_patterns
     # Pick one pattern at random to build the progression
@@ -286,21 +285,21 @@ def generate_random_chord_progression(key: str, length: int = 4) -> List[str]:
 
         note = notes[idx % len(notes)]
         if is_minor:
-            qualities = ['m', 'dim', '', 'm', 'm', '', '']
+            qualities = ["m", "dim", "", "m", "m", "", ""]
         else:
-            qualities = ['', 'm', 'm', '', '', 'm', 'dim']
+            qualities = ["", "m", "m", "", "", "m", "dim"]
         # Look up the chord quality for this scale degree (major, minor or diminished)
         quality = qualities[idx % len(qualities)]
-        chord = note + (quality if quality != 'dim' else '')
+        chord = note + (quality if quality != "dim" else "")
         if chord not in CHORDS:
             # Translate enharmonic spellings to match available chord names
             translation = {
-                'A#': 'Bb',
-                'A#m': 'Bbm',
-                'Db': 'C#',
-                'Dbm': 'C#m',
-                'Ab': 'G#',
-                'Abm': 'G#m',
+                "A#": "Bb",
+                "A#m": "Bbm",
+                "Db": "C#",
+                "Dbm": "C#m",
+                "Ab": "G#",
+                "Abm": "G#m",
             }
             chord = translation.get(chord, chord)
         return chord if chord in CHORDS else random.choice(list(CHORDS.keys()))
@@ -310,8 +309,10 @@ def generate_random_chord_progression(key: str, length: int = 4) -> List[str]:
     progression = [degree_to_chord(d) for d in degrees]
     if length > len(progression):
         # Pad the progression with random chords if the requested length is longer
-        extra = [degree_to_chord(random.randint(0, 5))
-                 for _ in range(length - len(progression))]
+        extra = [
+            degree_to_chord(random.randint(0, 5))
+            for _ in range(length - len(progression))
+        ]
         # Extend with random chords so the returned list matches ``length``
         progression.extend(extra)
     return progression[:length]
@@ -332,20 +333,24 @@ def diatonic_chords(key: str) -> List[str]:
     if key not in SCALE:
         raise ValueError(f"Unknown key '{key}'")
 
-    is_minor = key.endswith('m')
+    is_minor = key.endswith("m")
     notes = SCALE[key]
-    qualities = ['m', 'dim', '', 'm', 'm', '', ''] if is_minor else ['', 'm', 'm', '', '', 'm', 'dim']
+    qualities = (
+        ["m", "dim", "", "m", "m", "", ""]
+        if is_minor
+        else ["", "m", "m", "", "", "m", "dim"]
+    )
     chords = []
     translation = {
-        'A#': 'Bb',
-        'A#m': 'Bbm',
-        'Db': 'C#',
-        'Dbm': 'C#m',
-        'Ab': 'G#',
-        'Abm': 'G#m',
+        "A#": "Bb",
+        "A#m": "Bbm",
+        "Db": "C#",
+        "Dbm": "C#m",
+        "Ab": "G#",
+        "Abm": "G#m",
     }
     for note, qual in zip(notes, qualities):
-        chord = note + (qual if qual != 'dim' else '')
+        chord = note + (qual if qual != "dim" else "")
         if chord not in CHORDS:
             chord = translation.get(chord, chord)
         if chord in CHORDS and chord not in chords:
@@ -388,6 +393,7 @@ def generate_random_rhythm_pattern(length: int = 3) -> List[float]:
         pattern[idx] = random.choice(allowed)
 
     return pattern
+
 
 def note_to_midi(note: str) -> int:
     """Convert ``note`` strings such as ``C#4`` into MIDI numbers.
@@ -440,6 +446,7 @@ def note_to_midi(note: str) -> int:
     # MIDI note number is calculated relative to C0 at index 12
     return note_idx + (octave * 12)
 
+
 def midi_to_note(midi_note: int) -> str:
     """Convert a MIDI note number back to a note string.
 
@@ -451,6 +458,7 @@ def midi_to_note(midi_note: int) -> str:
     name = NOTES[midi_note % 12]
     return f"{name}{octave}"
 
+
 def get_interval(note1: str, note2: str) -> int:
     """Get the interval between two notes in semitones.
 
@@ -461,6 +469,7 @@ def get_interval(note1: str, note2: str) -> int:
     # Interval is the absolute difference in semitone numbers
     return abs(note_to_midi(note1) - note_to_midi(note2))
 
+
 def get_chord_notes(chord: str) -> List[str]:
     """Retrieve the notes that make up the given chord.
 
@@ -468,6 +477,7 @@ def get_chord_notes(chord: str) -> List[str]:
     @returns List[str]: Note names in the chord.
     """
     return CHORDS[chord]
+
 
 def generate_motif(length: int, key: str, base_octave: int = 4) -> List[str]:
     """Generate a motif (short, recurring musical idea) in the specified key.
@@ -483,6 +493,7 @@ def generate_motif(length: int, key: str, base_octave: int = 4) -> List[str]:
         random.choice(notes_in_key) + str(random.randint(base_octave, base_octave + 1))
         for _ in range(length)
     ]
+
 
 def generate_melody(
     key: str,
@@ -514,6 +525,8 @@ def generate_melody(
     @param chord_progression (List[str]): Chords guiding note choice.
     @param motif_length (int): Length of the initial motif.
     @param time_signature (Tuple[int, int]): Meter as ``(numerator, denominator)``.
+        The denominator must be one of ``1, 2, 4, 8`` or ``16`` so note
+        durations divide evenly into a whole note.
     @param pattern (List[float]|None): Optional rhythmic pattern. When provided,
         it must contain at least one duration value otherwise a ``ValueError`` is
         raised.
@@ -539,9 +552,19 @@ def generate_melody(
         raise ValueError("pattern must not be empty")
 
     # Validate the provided time signature so subsequent calculations never
-    # divide by zero or produce negative beat counts.
-    if time_signature[0] <= 0 or time_signature[1] <= 0:
-        raise ValueError("time_signature elements must be greater than 0")
+    # divide by zero or produce negative beat counts. ``time_signature[1]``
+    # is restricted to common musical denominators to keep rhythm calculations
+    # simple.
+    valid_denoms = {1, 2, 4, 8, 16}
+    if (
+        time_signature[0] <= 0
+        or time_signature[1] <= 0
+        or time_signature[1] not in valid_denoms
+    ):
+        raise ValueError(
+            "time_signature denominator must be one of 1, 2, 4, 8 or 16 and "
+            "numerator must be > 0"
+        )
     beat_unit = 1 / time_signature[1]
     start_beat = 0.0
 
@@ -579,9 +602,7 @@ def generate_melody(
             if name not in chord_notes:
                 closest = min(
                     chord_notes,
-                    key=lambda n: abs(
-                        note_to_midi(n + octv) - note_to_midi(melody[j])
-                    ),
+                    key=lambda n: abs(note_to_midi(n + octv) - note_to_midi(melody[j])),
                 )
                 melody[j] = closest + octv
         start_beat += pattern[j % len(pattern)] / beat_unit
@@ -659,7 +680,9 @@ def generate_melody(
         # Scan candidate pitches and keep track of which is closest to the
         # previous note. This gives a baseline for selecting smooth motion.
         for note in source_pool:
-            for octave in range(base_octave + octave_offset, base_octave + octave_offset + 2):
+            for octave in range(
+                base_octave + octave_offset, base_octave + octave_offset + 2
+            ):
                 candidate_note = note + str(octave)
                 interval = get_interval(prev_note, candidate_note)
                 if min_interval is None or interval < min_interval:
@@ -670,7 +693,9 @@ def generate_melody(
         if min_interval is not None:
             threshold = min_interval + 1
             for note in source_pool:
-                for octave in range(base_octave + octave_offset, base_octave + octave_offset + 2):
+                for octave in range(
+                    base_octave + octave_offset, base_octave + octave_offset + 2
+                ):
                     candidate_note = note + str(octave)
                     interval = get_interval(prev_note, candidate_note)
                     if interval <= threshold:
@@ -683,7 +708,9 @@ def generate_melody(
             )
             pool = chord_notes if strong else notes_in_key
             fallback_note = random.choice(pool) + str(
-                random.randint(base_octave + octave_offset, base_octave + octave_offset + 1)
+                random.randint(
+                    base_octave + octave_offset, base_octave + octave_offset + 1
+                )
             )
             candidates.append(fallback_note)
 
@@ -691,10 +718,14 @@ def generate_melody(
         # toward the origin by a small step.
         if leap_dir is not None:
             # Bias selection toward motion opposite the previous large leap
-            filtered = [c for c in candidates if (
-                (note_to_midi(c) - note_to_midi(prev_note)) * leap_dir < 0
-                and abs(note_to_midi(c) - note_to_midi(prev_note)) <= 2
-            )]
+            filtered = [
+                c
+                for c in candidates
+                if (
+                    (note_to_midi(c) - note_to_midi(prev_note)) * leap_dir < 0
+                    and abs(note_to_midi(c) - note_to_midi(prev_note)) <= 2
+                )
+            ]
             if filtered:
                 candidates = filtered
             leap_dir = None
@@ -792,13 +823,18 @@ def generate_counterpoint_melody(melody: List[str], key: str) -> List[str]:
             base_int = note_to_midi(base_note) - note_to_midi(prev_base)
             cand_int = note_to_midi(choice) - note_to_midi(prev_note)
             if base_int * cand_int > 0:
-                opposite = [c for c in candidates if (note_to_midi(c) - note_to_midi(prev_note)) * base_int < 0]
+                opposite = [
+                    c
+                    for c in candidates
+                    if (note_to_midi(c) - note_to_midi(prev_note)) * base_int < 0
+                ]
                 if opposite:
                     choice = random.choice(opposite)
         counter.append(choice)
         prev_note = choice
         prev_base = base_note
     return counter
+
 
 def create_midi_file(
     melody: List[str],
@@ -821,6 +857,8 @@ def create_midi_file(
     @param melody (List[str]): Sequence of note names representing the melody.
     @param bpm (int): Beats per minute.
     @param time_signature (Tuple[int, int]): ``(numerator, denominator)`` pair.
+        The denominator must be one of ``1, 2, 4, 8`` or ``16`` so durations
+        align with standard note values.
     @param output_file (str): Destination file path.
     @param harmony (bool): Include a simple harmony line.
     @param pattern (List[float]|None): Optional rhythmic pattern. If provided it
@@ -832,8 +870,16 @@ def create_midi_file(
     @param program (int): General MIDI instrument program for the melody.
     @returns None: MIDI data is written to ``output_file``.
     """
-    if time_signature[0] <= 0 or time_signature[1] <= 0:
-        raise ValueError("time_signature elements must be greater than 0")
+    valid_denoms = {1, 2, 4, 8, 16}
+    if (
+        time_signature[0] <= 0
+        or time_signature[1] <= 0
+        or time_signature[1] not in valid_denoms
+    ):
+        raise ValueError(
+            "time_signature denominator must be one of 1, 2, 4, 8 or 16 and "
+            "numerator must be > 0"
+        )
     ticks_per_beat = 480
     mid = MidiFile(ticks_per_beat=ticks_per_beat)
     track = MidiTrack()
@@ -858,13 +904,13 @@ def create_midi_file(
             mid.tracks.append(chord_track)
 
     # Set tempo and time signature.
-    track.append(mido.MetaMessage('set_tempo', tempo=mido.bpm2tempo(bpm)))
+    track.append(mido.MetaMessage("set_tempo", tempo=mido.bpm2tempo(bpm)))
     track.append(
         mido.MetaMessage(
-            'time_signature', numerator=time_signature[0], denominator=time_signature[1]
+            "time_signature", numerator=time_signature[0], denominator=time_signature[1]
         )
     )
-    track.append(Message('program_change', program=program, time=0))
+    track.append(Message("program_change", program=program, time=0))
 
     # Select a rhythmic pattern and compute the duration of a whole note in ticks.
     if pattern is None:
@@ -902,14 +948,26 @@ def create_midi_file(
         note_duration = int(duration_fraction * whole_note_ticks)
         midi_note = note_to_midi(note)
 
-        note_on = Message('note_on', note=midi_note, velocity=velocity, time=rest_ticks)
-        note_off = Message('note_off', note=midi_note, velocity=velocity, time=note_duration)
+        note_on = Message("note_on", note=midi_note, velocity=velocity, time=rest_ticks)
+        note_off = Message(
+            "note_off", note=midi_note, velocity=velocity, time=note_duration
+        )
         track.append(note_on)
         track.append(note_off)
         if harmony_track is not None:
             harmony_note = min(midi_note + 4, 127)
-            h_on = Message('note_on', note=harmony_note, velocity=max(velocity - 10, 40), time=rest_ticks)
-            h_off = Message('note_off', note=harmony_note, velocity=max(velocity - 10, 40), time=note_duration)
+            h_on = Message(
+                "note_on",
+                note=harmony_note,
+                velocity=max(velocity - 10, 40),
+                time=rest_ticks,
+            )
+            h_off = Message(
+                "note_off",
+                note=harmony_note,
+                velocity=max(velocity - 10, 40),
+                time=note_duration,
+            )
             harmony_track.append(h_on)
             harmony_track.append(h_off)
         # Write notes for any additional melody lines in lockstep with the main
@@ -918,8 +976,8 @@ def create_midi_file(
             if i >= len(line):
                 continue
             m = note_to_midi(line[i])
-            x_on = Message('note_on', note=m, velocity=velocity, time=rest_ticks)
-            x_off = Message('note_off', note=m, velocity=velocity, time=note_duration)
+            x_on = Message("note_on", note=m, velocity=velocity, time=rest_ticks)
+            x_off = Message("note_off", note=m, velocity=velocity, time=note_duration)
             t.append(x_on)
             t.append(x_off)
 
@@ -934,8 +992,10 @@ def create_midi_file(
             if last_note is not None and random.random() < 0.5:
                 extra_fraction = random.choice([0.5, 1.0])
                 extra_ticks = int(extra_fraction * whole_note_ticks)
-                on = Message('note_on', note=last_note, velocity=last_velocity, time=0)
-                off = Message('note_off', note=last_note, velocity=last_velocity, time=extra_ticks)
+                on = Message("note_on", note=last_note, velocity=last_velocity, time=0)
+                off = Message(
+                    "note_off", note=last_note, velocity=last_velocity, time=extra_ticks
+                )
                 track.append(on)
                 track.append(off)
                 rest_ticks = beat_ticks
@@ -944,7 +1004,9 @@ def create_midi_file(
     if chord_track is not None:
         # Compute when each chord should start and end using absolute ticks so
         # merged chords align with the melody when ``chords_separate`` is False.
-        ticks_per_measure = int(time_signature[0] * ticks_per_beat * (4 / time_signature[1]))
+        ticks_per_measure = int(
+            time_signature[0] * ticks_per_beat * (4 / time_signature[1])
+        )
         ticks_per_chord = ticks_per_measure
         total_ticks = int(total_beats * ticks_per_beat * (4 / time_signature[1]))
         num_chords = max(1, math.ceil(total_ticks / ticks_per_chord))
@@ -956,8 +1018,15 @@ def create_midi_file(
             notes = CHORDS.get(chord, [])
             for note in notes:
                 note_num = note_to_midi(note + "3")
-                chord_events.append((start_tick, Message('note_on', note=note_num, velocity=60, time=0)))
-                chord_events.append((start_tick + ticks_per_chord, Message('note_off', note=note_num, velocity=60, time=0)))
+                chord_events.append(
+                    (start_tick, Message("note_on", note=note_num, velocity=60, time=0))
+                )
+                chord_events.append(
+                    (
+                        start_tick + ticks_per_chord,
+                        Message("note_off", note=note_num, velocity=60, time=0),
+                    )
+                )
 
         if chords_separate:
             # Convert absolute times to delta times relative to the chord track.
@@ -1011,14 +1080,17 @@ def _open_default_player(path: str, *, delete_after: bool = False) -> None:
                     subprocess.run(cmd, check=False)
                 else:
                     # ``start`` returns immediately unless ``/wait`` is used.
-                    subprocess.run([
-                        "cmd",
-                        "/c",
-                        "start",
-                        "/wait",
-                        "",
-                        path,
-                    ], check=False)
+                    subprocess.run(
+                        [
+                            "cmd",
+                            "/c",
+                            "start",
+                            "/wait",
+                            "",
+                            path,
+                        ],
+                        check=False,
+                    )
             elif sys.platform == "darwin":
                 if player:
                     subprocess.run(["open", "-W", "-a", player, path], check=False)
@@ -1040,6 +1112,7 @@ def _open_default_player(path: str, *, delete_after: bool = False) -> None:
 
     threading.Thread(target=runner, daemon=True).start()
 
+
 def run_cli() -> None:
     """Parse command line arguments and generate a melody.
 
@@ -1056,32 +1129,87 @@ def run_cli() -> None:
     parser = argparse.ArgumentParser(
         description="Generate a random melody and save as a MIDI file."
     )
-    parser.add_argument('--key', type=str, required=True, help="Musical key (e.g., C, Dm, etc.).")
-    parser.add_argument('--chords', type=str, help="Comma-separated chord progression (e.g., C,Am,F,G).")
-    parser.add_argument('--random-chords', type=int, metavar='N', help="Generate a random chord progression of N chords, ignoring --chords.")
-    parser.add_argument('--bpm', type=int, required=True, help="Beats per minute (integer).")
-    parser.add_argument('--timesig', type=str, required=True, help="Time signature in numerator/denominator format (e.g., 4/4).")
-    parser.add_argument('--notes', type=int, required=True, help="Number of notes in the melody.")
-    parser.add_argument('--output', type=str, required=True, help="Output MIDI file path.")
-    parser.add_argument('--motif_length', type=int, default=4, help="Length of the initial motif (default: 4).")
-    parser.add_argument('--harmony', action='store_true', help="Add a simple harmony track.")
-    parser.add_argument('--random-rhythm', action='store_true', help="Generate a random rhythmic pattern.")
-    parser.add_argument('--counterpoint', action='store_true', help="Generate a counterpoint line.")
-    parser.add_argument('--harmony-lines', type=int, default=0, metavar='N',
-                        help="Number of harmony lines to add in parallel")
-    parser.add_argument('--base-octave', type=int, default=4,
-                        help="Starting octave for the melody (default: 4).")
-    parser.add_argument('--include-chords', action='store_true',
-                        help='Add the chord progression to the MIDI output')
-    parser.add_argument('--chords-same-track', action='store_true',
-                        help='Write chords on the melody track instead of a new one')
-    parser.add_argument('--instrument', type=int, default=0,
-                        help='MIDI program number for the melody instrument')
-    parser.add_argument('--soundfont', type=str,
-                        help='Path to a SoundFont (.sf2) file used when '\
-                             'previewing with --play')
-    parser.add_argument('--play', action='store_true',
-                        help='Play the MIDI file after it is created')
+    parser.add_argument(
+        "--key", type=str, required=True, help="Musical key (e.g., C, Dm, etc.)."
+    )
+    parser.add_argument(
+        "--chords", type=str, help="Comma-separated chord progression (e.g., C,Am,F,G)."
+    )
+    parser.add_argument(
+        "--random-chords",
+        type=int,
+        metavar="N",
+        help="Generate a random chord progression of N chords, ignoring --chords.",
+    )
+    parser.add_argument(
+        "--bpm", type=int, required=True, help="Beats per minute (integer)."
+    )
+    parser.add_argument(
+        "--timesig",
+        type=str,
+        required=True,
+        help="Time signature in numerator/denominator format (e.g., 4/4).",
+    )
+    parser.add_argument(
+        "--notes", type=int, required=True, help="Number of notes in the melody."
+    )
+    parser.add_argument(
+        "--output", type=str, required=True, help="Output MIDI file path."
+    )
+    parser.add_argument(
+        "--motif_length",
+        type=int,
+        default=4,
+        help="Length of the initial motif (default: 4).",
+    )
+    parser.add_argument(
+        "--harmony", action="store_true", help="Add a simple harmony track."
+    )
+    parser.add_argument(
+        "--random-rhythm",
+        action="store_true",
+        help="Generate a random rhythmic pattern.",
+    )
+    parser.add_argument(
+        "--counterpoint", action="store_true", help="Generate a counterpoint line."
+    )
+    parser.add_argument(
+        "--harmony-lines",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Number of harmony lines to add in parallel",
+    )
+    parser.add_argument(
+        "--base-octave",
+        type=int,
+        default=4,
+        help="Starting octave for the melody (default: 4).",
+    )
+    parser.add_argument(
+        "--include-chords",
+        action="store_true",
+        help="Add the chord progression to the MIDI output",
+    )
+    parser.add_argument(
+        "--chords-same-track",
+        action="store_true",
+        help="Write chords on the melody track instead of a new one",
+    )
+    parser.add_argument(
+        "--instrument",
+        type=int,
+        default=0,
+        help="MIDI program number for the melody instrument",
+    )
+    parser.add_argument(
+        "--soundfont",
+        type=str,
+        help="Path to a SoundFont (.sf2) file used when " "previewing with --play",
+    )
+    parser.add_argument(
+        "--play", action="store_true", help="Play the MIDI file after it is created"
+    )
     # Parse the provided CLI arguments
     args = parser.parse_args()
 
@@ -1111,12 +1239,14 @@ def run_cli() -> None:
 
     if args.random_chords:
         # Let the helper pick a progression based solely on the key
-        chord_progression = generate_random_chord_progression(args.key, args.random_chords)
+        chord_progression = generate_random_chord_progression(
+            args.key, args.random_chords
+        )
     else:
         if not args.chords:
             logging.error("Chord progression required unless --random-chords is used.")
             sys.exit(1)
-        chord_progression = [chord.strip() for chord in args.chords.split(',')]
+        chord_progression = [chord.strip() for chord in args.chords.split(",")]
         # Validate that every chord exists in the chord dictionary
         for chord in chord_progression:
             if chord not in CHORDS:
@@ -1124,16 +1254,18 @@ def run_cli() -> None:
                 sys.exit(1)
 
     try:
-        # Parse "numerator/denominator" into two integers
-        parts = args.timesig.split('/')
+        # Parse "numerator/denominator" into two integers and enforce
+        # a denominator drawn from common note values.
+        parts = args.timesig.split("/")
         if len(parts) != 2:
             raise ValueError
         numerator, denominator = map(int, parts)
-        if numerator <= 0 or denominator <= 0:
+        if numerator <= 0 or denominator not in {1, 2, 4, 8, 16}:
             raise ValueError
     except ValueError:
         logging.error(
-            "Time signature must be two integers in the form 'numerator/denominator' with numerator > 0 and denominator > 0."
+            "Time signature must be in the form 'numerator/denominator' with "
+            "numerator > 0 and denominator one of 1, 2, 4, 8 or 16."
         )
         sys.exit(1)
 
@@ -1167,6 +1299,7 @@ def run_cli() -> None:
     if args.play:
         try:
             from . import playback
+
             playback.play_midi(args.output, soundfont=args.soundfont)
         except Exception:
             _open_default_player(args.output)
@@ -1182,7 +1315,7 @@ def main() -> None:
     @returns None: This function does not return.
     """
     # Configure logging only when executing the application directly
-    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     # Decide between CLI and GUI based on whether arguments were supplied
     if len(sys.argv) > 1:
@@ -1217,6 +1350,6 @@ def main() -> None:
         # Start the Tk event loop
         gui.run()
 
-if __name__ == '__main__':
-    main()
 
+if __name__ == "__main__":
+    main()

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -30,6 +30,7 @@ import threading
 from tempfile import NamedTemporaryFile
 
 from . import diatonic_chords
+
 # ``MidiPlaybackError`` signals that preview playback failed within the
 # ``playback`` helper module. Catching it allows the GUI to fall back to the
 # system default player without masking unrelated errors.
@@ -45,6 +46,7 @@ INSTRUMENTS = {
     "Violin": 40,
     "Flute": 73,
 }
+
 
 class MelodyGeneratorGUI:
     """Tkinter-based GUI for melody generation."""
@@ -255,11 +257,14 @@ class MelodyGeneratorGUI:
         """Indicate whether preview playback can function."""
         try:
             from . import playback
+
             playback._resolve_soundfont(self.soundfont_var.get() or None)
         except Exception:
             self.preview_available = False
             if hasattr(self, "preview_notice"):
-                self.preview_notice.config(text="Preview requires FluidSynth and a SoundFont")
+                self.preview_notice.config(
+                    text="Preview requires FluidSynth and a SoundFont"
+                )
         else:
             self.preview_available = True
             if hasattr(self, "preview_notice"):
@@ -277,15 +282,22 @@ class MelodyGeneratorGUI:
         ttk.Label(frame, text="Key:").grid(row=0, column=0, sticky="w")
         self.key_var = tk.StringVar()
         key_combobox = ttk.Combobox(
-            frame, textvariable=self.key_var, values=list(self.scale.keys()), state="readonly"
+            frame,
+            textvariable=self.key_var,
+            values=list(self.scale.keys()),
+            state="readonly",
         )
         key_combobox.grid(row=0, column=1)
         key_combobox.current(0)
         key_combobox.bind("<<ComboboxSelected>>", lambda _e: self._update_chord_list())
 
         # Chord progression listbox
-        ttk.Label(frame, text="Chord Progression (Select multiple):").grid(row=1, column=0, sticky="w")
-        self.chord_listbox = tk.Listbox(frame, selectmode=tk.MULTIPLE, height=10, bg="white")
+        ttk.Label(frame, text="Chord Progression (Select multiple):").grid(
+            row=1, column=0, sticky="w"
+        )
+        self.chord_listbox = tk.Listbox(
+            frame, selectmode=tk.MULTIPLE, height=10, bg="white"
+        )
         self._update_chord_list()
         self.chord_listbox.grid(row=1, column=1)
 
@@ -364,7 +376,9 @@ class MelodyGeneratorGUI:
         # SoundFont selection path used by FluidSynth
         ttk.Label(frame, text="SoundFont:").grid(row=7, column=0, sticky="w")
         self.soundfont_var = tk.StringVar(value=os.environ.get("SOUND_FONT", ""))
-        self.soundfont_entry = ttk.Entry(frame, textvariable=self.soundfont_var, width=25)
+        self.soundfont_entry = ttk.Entry(
+            frame, textvariable=self.soundfont_var, width=25
+        )
         self.soundfont_entry.grid(row=7, column=1)
         ttk.Button(
             frame,
@@ -466,7 +480,9 @@ class MelodyGeneratorGUI:
         key = self.key_var.get()
         selected_indices = self.chord_listbox.curselection()
         if not selected_indices:
-            messagebox.showerror("Input Error", "Please select at least one chord for the progression.")
+            messagebox.showerror(
+                "Input Error", "Please select at least one chord for the progression."
+            )
             return
         # Build the chord progression from the selected listbox entries
         displays = [self.chord_listbox.get(i) for i in selected_indices]
@@ -481,24 +497,27 @@ class MelodyGeneratorGUI:
             if len(ts_parts) != 2:
                 raise ValueError
             numerator, denominator = map(int, ts_parts)
-            if numerator <= 0 or denominator <= 0:
+            if numerator <= 0 or denominator not in {1, 2, 4, 8, 16}:
                 raise ValueError
         except ValueError:
             # Show one error message for any invalid numeric input
             messagebox.showerror(
                 "Input Error",
-                "Ensure BPM, Number of Notes, and Motif Length are integers and Time Signature is formatted as 'numerator/denominator'.",
+                "Ensure BPM, Number of Notes, and Motif Length are integers and "
+                "Time Signature is formatted as 'numerator/denominator' with "
+                "denominator one of 1, 2, 4, 8 or 16.",
             )
             return
 
         if motif_length > notes_count:
             messagebox.showerror(
-                "Input Error",
-                "Motif length cannot exceed the number of notes."
+                "Input Error", "Motif length cannot exceed the number of notes."
             )
             return
 
-        output_file = filedialog.asksaveasfilename(defaultextension=".mid", filetypes=[("MIDI files", "*.mid")])
+        output_file = filedialog.asksaveasfilename(
+            defaultextension=".mid", filetypes=[("MIDI files", "*.mid")]
+        )
         if output_file:
             melody = self.generate_melody(
                 key,
@@ -527,7 +546,9 @@ class MelodyGeneratorGUI:
                 harmony=self.harmony_var.get(),
                 pattern=self.rhythm_pattern,
                 extra_tracks=extra,
-                chord_progression=chord_progression if self.include_chords_var.get() else None,
+                chord_progression=(
+                    chord_progression if self.include_chords_var.get() else None
+                ),
                 chords_separate=not self.chords_same_var.get(),
                 program=INSTRUMENTS.get(self.instrument_var.get(), 0),
             )
@@ -566,12 +587,14 @@ class MelodyGeneratorGUI:
             if len(ts_parts) != 2:
                 raise ValueError
             numerator, denominator = map(int, ts_parts)
-            if numerator <= 0 or denominator <= 0:
+            if numerator <= 0 or denominator not in {1, 2, 4, 8, 16}:
                 raise ValueError
         except ValueError:
             messagebox.showerror(
                 "Input Error",
-                "Ensure BPM, Number of Notes, and Motif Length are integers and Time Signature is formatted as 'numerator/denominator'.",
+                "Ensure BPM, Number of Notes, and Motif Length are integers and "
+                "Time Signature is formatted as 'numerator/denominator' with "
+                "denominator one of 1, 2, 4, 8 or 16.",
             )
             return
 
@@ -616,6 +639,7 @@ class MelodyGeneratorGUI:
         playback_succeeded = False
         try:
             from . import playback
+
             try:
                 playback.play_midi(tmp_path, soundfont=self.soundfont_var.get() or None)
                 playback_succeeded = True
@@ -648,14 +672,17 @@ class MelodyGeneratorGUI:
                     if player:
                         subprocess.run([player, path], check=False)
                     else:
-                        subprocess.run([
-                            "cmd",
-                            "/c",
-                            "start",
-                            "/wait",
-                            "",
-                            path,
-                        ], check=False)
+                        subprocess.run(
+                            [
+                                "cmd",
+                                "/c",
+                                "start",
+                                "/wait",
+                                "",
+                                path,
+                            ],
+                            check=False,
+                        )
                 elif sys.platform == "darwin":
                     if player:
                         subprocess.run(["open", "-W", "-a", player, path], check=False)
@@ -667,7 +694,9 @@ class MelodyGeneratorGUI:
                     else:
                         subprocess.run(["xdg-open", path], check=False)
             except Exception as exc:  # pragma: no cover - platform dependent
-                messagebox.showerror("Preview Error", f"Could not open MIDI file: {exc}")
+                messagebox.showerror(
+                    "Preview Error", f"Could not open MIDI file: {exc}"
+                )
             finally:
                 if delete_after:
                     try:

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -13,6 +13,8 @@ import random
 
 # Provide a minimal stub for the 'mido' module so the import succeeds
 stub_mido = types.ModuleType("mido")
+
+
 class DummyMessage:
     """Lightweight MIDI message holding only relevant attributes."""
 
@@ -75,8 +77,8 @@ def test_note_to_midi_sharp_and_flat():
 
     ``C#4`` and ``Db4`` as well as ``F#5`` and ``Gb5`` should yield identical
     numbers when converted via ``note_to_midi``."""
-    assert note_to_midi('C#4') == note_to_midi('Db4')
-    assert note_to_midi('F#5') == note_to_midi('Gb5')
+    assert note_to_midi("C#4") == note_to_midi("Db4")
+    assert note_to_midi("F#5") == note_to_midi("Gb5")
 
 
 def test_generate_melody_length_and_error():
@@ -85,12 +87,12 @@ def test_generate_melody_length_and_error():
     A valid call with eight notes should produce exactly eight results.
     Requesting fewer notes than the motif length should raise
     ``ValueError``."""
-    chords = ['C', 'G', 'Am', 'F']
-    melody = generate_melody('C', 8, chords, motif_length=4)
+    chords = ["C", "G", "Am", "F"]
+    melody = generate_melody("C", 8, chords, motif_length=4)
     assert len(melody) == 8
 
     with pytest.raises(ValueError):
-        generate_melody('C', 3, chords, motif_length=4)
+        generate_melody("C", 3, chords, motif_length=4)
 
 
 def test_generate_melody_invalid_denominator():
@@ -98,9 +100,12 @@ def test_generate_melody_invalid_denominator():
 
     ``generate_melody`` should reject denominators other than ``1, 2, 4, 8`` or
     ``16``. Passing ``(4, 0)`` exercises this validation branch."""
-    chords = ['C', 'G']
+    chords = ["C", "G"]
     with pytest.raises(ValueError):
-        generate_melody('C', 4, chords, motif_length=4, time_signature=(4, 0))
+        generate_melody("C", 4, chords, motif_length=4, time_signature=(4, 0))
+    # Denominator values outside {1,2,4,8,16} should also be rejected
+    with pytest.raises(ValueError):
+        generate_melody("C", 4, chords, motif_length=4, time_signature=(4, 3))
 
 
 def test_generate_melody_invalid_numerator_and_negative_denominator():
@@ -108,11 +113,11 @@ def test_generate_melody_invalid_numerator_and_negative_denominator():
 
     Passing a numerator of ``0`` or a negative denominator should result in a
     ``ValueError`` to guard against nonsensical time signatures."""
-    chords = ['C', 'G']
+    chords = ["C", "G"]
     with pytest.raises(ValueError):
-        generate_melody('C', 4, chords, motif_length=4, time_signature=(0, 4))
+        generate_melody("C", 4, chords, motif_length=4, time_signature=(0, 4))
     with pytest.raises(ValueError):
-        generate_melody('C', 4, chords, motif_length=4, time_signature=(4, -1))
+        generate_melody("C", 4, chords, motif_length=4, time_signature=(4, -1))
 
 
 def test_generate_melody_empty_pattern():
@@ -121,9 +126,9 @@ def test_generate_melody_empty_pattern():
     The melody generation logic cycles through the pattern list, so an empty
     list would lead to divide-by-zero errors. Validate that the function
     proactively rejects this."""
-    chords = ['C', 'G']
+    chords = ["C", "G"]
     with pytest.raises(ValueError):
-        generate_melody('C', 4, chords, motif_length=4, pattern=[])
+        generate_melody("C", 4, chords, motif_length=4, pattern=[])
 
 
 def test_create_midi_file_invalid_time_signature(tmp_path):
@@ -131,14 +136,17 @@ def test_create_midi_file_invalid_time_signature(tmp_path):
 
     Each invalid signature should result in a ``ValueError`` before any file is
     written to disk."""
-    melody = ['C4'] * 4
-    out = tmp_path / 'bad.mid'
+    melody = ["C4"] * 4
+    out = tmp_path / "bad.mid"
     with pytest.raises(ValueError):
         create_midi_file(melody, 120, (0, 4), str(out))
     with pytest.raises(ValueError):
         create_midi_file(melody, 120, (4, 0), str(out))
     with pytest.raises(ValueError):
         create_midi_file(melody, 120, (4, -3), str(out))
+    # Non-standard denominators such as 5 should be rejected
+    with pytest.raises(ValueError):
+        create_midi_file(melody, 120, (4, 5), str(out))
 
 
 def test_create_midi_file_empty_pattern(tmp_path):
@@ -147,8 +155,8 @@ def test_create_midi_file_empty_pattern(tmp_path):
     ``create_midi_file`` cycles through the provided list when scheduling MIDI
     events. A zero-length list would result in ``ZeroDivisionError`` when
     indexing with ``i % len(pattern)``."""
-    melody = ['C4'] * 4
-    out = tmp_path / 'empty.mid'
+    melody = ["C4"] * 4
+    out = tmp_path / "empty.mid"
     with pytest.raises(ValueError):
         create_midi_file(melody, 120, (4, 4), str(out), pattern=[])
 
@@ -158,11 +166,11 @@ def test_extra_tracks_created(tmp_path):
 
     After calling the function with harmony and counterpoint lines the resulting
     ``MidiFile`` should contain one primary track plus two additional tracks."""
-    chords = ['C', 'G', 'Am', 'F']
-    melody = generate_melody('C', 8, chords, motif_length=4)
+    chords = ["C", "G", "Am", "F"]
+    melody = generate_melody("C", 8, chords, motif_length=4)
     harmony = generate_harmony_line(melody)
-    cp = generate_counterpoint_melody(melody, 'C')
-    out = tmp_path / 'm.mid'
+    cp = generate_counterpoint_melody(melody, "C")
+    out = tmp_path / "m.mid"
     create_midi_file(
         melody,
         120,
@@ -182,11 +190,11 @@ def test_extra_tracks_shorter_line(tmp_path):
 
     ``create_midi_file`` should not assume all tracks are equal length; truncated
     harmony or counterpoint lines must be padded appropriately."""
-    chords = ['C', 'G', 'Am', 'F']
-    melody = generate_melody('C', 6, chords, motif_length=4)
+    chords = ["C", "G", "Am", "F"]
+    melody = generate_melody("C", 6, chords, motif_length=4)
     harmony = generate_harmony_line(melody)[:3]
-    cp = generate_counterpoint_melody(melody, 'C')[:5]
-    out = tmp_path / 'short.mid'
+    cp = generate_counterpoint_melody(melody, "C")[:5]
+    out = tmp_path / "short.mid"
     create_midi_file(
         melody,
         120,
@@ -342,8 +350,12 @@ def test_melody_trends_up_then_down():
     first_half = midi_vals[:mid]
     second_half = midi_vals[mid:]
 
-    up_trend = sum(b - a for a, b in zip(first_half, first_half[1:])) / (len(first_half) - 1)
-    down_trend = sum(b - a for a, b in zip(second_half, second_half[1:])) / (len(second_half) - 1)
+    up_trend = sum(b - a for a, b in zip(first_half, first_half[1:])) / (
+        len(first_half) - 1
+    )
+    down_trend = sum(b - a for a, b in zip(second_half, second_half[1:])) / (
+        len(second_half) - 1
+    )
 
     assert up_trend >= 0
     assert down_trend <= 0


### PR DESCRIPTION
## Summary
- restrict valid time signature denominators to {1,2,4,8,16}
- clarify CLI and GUI error messages about allowed denominators
- unit tests for invalid denominators such as 3 or 5

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ebeaa0b24832181fb070cef88d679