### PR TITLE
Validate base octave range

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ and use the web interface without installing Python locally.
 - **Harmony**: Tick this option to add a simple harmony line.
 - **Counterpoint**: Generates an additional melody that moves against the main line.
 - **Base Octave**: Starting octave for the melody. Use the slider or
-  `--base-octave` flag to shift the register. Notes typically stay
-  between this octave and the next higher one with rare octave shifts at
-  phrase boundaries.
+  `--base-octave` flag to shift the register. Allowed range is **0-8** so
+  all generated notes remain within the MIDI specification. Notes
+  typically stay between this octave and the next higher one with rare
+  octave shifts at phrase boundaries.
 
 ## CLI Flags
 When running from the command line you can supply optional flags:
@@ -156,7 +157,8 @@ When running from the command line you can supply optional flags:
 - `--harmony` adds a parallel harmony track.
 - `--harmony-lines N` creates `N` additional harmony parts.
 - `--counterpoint` generates a contrapuntal line based on the melody.
-- `--base-octave N` sets the starting octave of the melody (default: 4).
+- `--base-octave N` sets the starting octave of the melody (0-8,
+  default: 4).
 - `--play` previews the resulting MIDI file using FluidSynth when available and
   falls back to the system player otherwise.
 - `--soundfont PATH` uses the specified SoundFont when playing the file with

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -17,6 +17,8 @@ is delegated to :mod:`melody_generator`.
 #   with range validation.
 # * ``_check_preview_available`` displays a notice when FluidSynth or a
 #   SoundFont is unavailable for preview playback.
+# * ``_generate_button_click`` now validates ``base_octave`` to ensure it
+#   stays within the MIDI range 0-8 before generating a melody.
 # ---------------------------------------------------------------
 from __future__ import annotations
 
@@ -515,6 +517,16 @@ class MelodyGeneratorGUI:
             )
             return
 
+        # Reject octave selections outside the safe MIDI range. The GUI slider
+        # limits values to 1-7 but loading settings from disk may yield other
+        # numbers.
+        base_octave = self.base_octave_var.get()
+        if base_octave < 0 or base_octave > 8:
+            messagebox.showerror(
+                "Input Error", "Base octave must be between 0 and 8."
+            )
+            return
+
         output_file = filedialog.asksaveasfilename(
             defaultextension=".mid", filetypes=[("MIDI files", "*.mid")]
         )
@@ -524,7 +536,7 @@ class MelodyGeneratorGUI:
                 notes_count,
                 chord_progression,
                 motif_length=motif_length,
-                base_octave=self.base_octave_var.get(),
+                base_octave=base_octave,
             )
             extra: List[List[str]] = []
             if self.harmony_line_fn is not None:

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -7,6 +7,9 @@ by the :mod:`melody_generator` package. The goal is to expose the
 melody generation functions over HTTP so users can experiment
 directly from their browser.
 """
+# This revision introduces validation for the ``base_octave`` input so
+# out-of-range values (anything not between 0 and 8) trigger a flash
+# message instead of causing errors when generating the melody.
 # The original implementation attempted to render the generated MIDI to WAV
 # using FluidSynth so that browsers lacking MIDI support could preview the
 # melody. This update flashes an informative message when that rendering
@@ -131,6 +134,10 @@ def index():
 
         if motif_length > notes:
             flash("Motif length cannot exceed the number of notes.")
+            return render_template('index.html', scale=sorted(SCALE.keys()), instruments=INSTRUMENTS.keys())
+
+        if base_octave < 0 or base_octave > 8:
+            flash("Base octave must be between 0 and 8.")
             return render_template('index.html', scale=sorted(SCALE.keys()), instruments=INSTRUMENTS.keys())
         melody = generate_melody(
             key,

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -445,6 +445,42 @@ def test_generate_button_click_motif_exceeds_notes(tmp_path, monkeypatch):
     assert errs
 
 
+def test_generate_button_click_invalid_base_octave(tmp_path, monkeypatch):
+    """Out-of-range base octave values trigger an error dialog."""
+
+    mod, gui_mod, _ = load_module()
+    gui = gui_mod.MelodyGeneratorGUI.__new__(gui_mod.MelodyGeneratorGUI)
+    gui.generate_melody = lambda *a, **k: []
+    gui.create_midi_file = lambda *a, **k: None
+    gui.harmony_line_fn = None
+    gui.counterpoint_fn = None
+    gui.save_settings = None
+    gui.rhythm_pattern = None
+    gui.key_var = types.SimpleNamespace(get=lambda: "C")
+    gui.bpm_var = types.SimpleNamespace(get=lambda: 120)
+    gui.timesig_var = types.SimpleNamespace(get=lambda: "4/4")
+    gui.notes_var = types.SimpleNamespace(get=lambda: 4)
+    gui.motif_entry = types.SimpleNamespace(get=lambda: "2")
+    gui.base_octave_var = types.SimpleNamespace(get=lambda: 9)
+    gui.harmony_var = types.SimpleNamespace(get=lambda: False)
+    gui.counterpoint_var = types.SimpleNamespace(get=lambda: False)
+    gui.harmony_lines = types.SimpleNamespace(get=lambda: "0")
+    lb = types.SimpleNamespace(curselection=lambda: (0,), get=lambda idx: "C")
+    gui.chord_listbox = lb
+    gui.display_map = {"C": "C"}
+    gui.sorted_chords = ["C"]
+
+    monkeypatch.setattr(
+        gui_mod.filedialog, "asksaveasfilename", lambda **k: str(tmp_path / "x.mid"), raising=False
+    )
+    errs = []
+    monkeypatch.setattr(mod.gui.messagebox, "showerror", lambda *a, **k: errs.append(a), raising=False)
+
+    gui._generate_button_click()
+
+    assert errs
+
+
 def test_cli_invalid_timesig_exits(tmp_path):
     """CLI should exit when the time signature is malformed.
 
@@ -597,6 +633,35 @@ def test_cli_invalid_instrument_number_exit(tmp_path):
         str(out),
         "--instrument",
         "128",
+    ]
+    old = sys.argv
+    sys.argv = argv
+    with pytest.raises(SystemExit):
+        mod.run_cli()
+    sys.argv = old
+
+
+def test_cli_invalid_base_octave_exit(tmp_path):
+    """``run_cli`` should exit when ``--base-octave`` is outside 0-8."""
+
+    mod, _, _ = load_module()
+    out = tmp_path / "bad.mid"
+    argv = [
+        "prog",
+        "--key",
+        "C",
+        "--chords",
+        "C,G",
+        "--bpm",
+        "120",
+        "--timesig",
+        "4/4",
+        "--notes",
+        "4",
+        "--base-octave",
+        "9",
+        "--output",
+        str(out),
     ]
     old = sys.argv
     sys.argv = argv

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -131,6 +131,20 @@ def test_generate_melody_empty_pattern():
         generate_melody("C", 4, chords, motif_length=4, pattern=[])
 
 
+def test_generate_melody_invalid_base_octave():
+    """Out-of-range ``base_octave`` values should raise ``ValueError``.
+
+    The melody generator clamps notes based on ``base_octave``. Supplying a
+    value below 0 or above 8 would result in MIDI numbers outside 0-127, so
+    the function rejects them.
+    """
+    chords = ["C", "G"]
+    with pytest.raises(ValueError):
+        generate_melody("C", 4, chords, motif_length=4, base_octave=-1)
+    with pytest.raises(ValueError):
+        generate_melody("C", 4, chords, motif_length=4, base_octave=9)
+
+
 def test_create_midi_file_invalid_time_signature(tmp_path):
     """``create_midi_file`` rejects malformed time signatures.
 

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -143,6 +143,25 @@ def test_motif_exceeds_notes_flash():
     assert b"Motif length cannot exceed" in resp.data
 
 
+def test_invalid_base_octave_flash():
+    """Out-of-range ``base_octave`` values return an error flash."""
+
+    client = app.test_client()
+    resp = client.post(
+        "/",
+        data={
+            "key": "C",
+            "chords": "C",
+            "bpm": "120",
+            "timesig": "4/4",
+            "notes": "8",
+            "motif_length": "4",
+            "base_octave": "9",
+        },
+    )
+    assert b"Base octave must be" in resp.data
+
+
 def test_invalid_chord_flash():
     """Unknown chords in the form post return an error flash."""
     client = app.test_client()


### PR DESCRIPTION
## Summary
- enforce safe base_octave range in `generate_melody`
- validate CLI, desktop GUI and Flask web inputs
- document valid range in README
- add regression tests for invalid base_octave

## Testing
- `ruff check .`
- `pytest -q`