### PR TITLE
Add Linux and Windows setup helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install Flask pytest
+      - name: Lint with ruff
+        run: |
+          python -m pip install ruff
+          ruff check .
       - name: Run tests
         run: pytest

--- a/README.md
+++ b/README.md
@@ -47,6 +47,30 @@ Tkinter powers the GUI and may need to be installed manually, e.g. `apt-get inst
 For audio playback a General MIDI soundfont such as the optional `fluid-soundfont-gm` package is recommended.
 On platforms without a prebuilt PyFluidSynth wheel you might also need the Fluidsynth development headers: `apt-get install libfluidsynth-dev`.
 
+### Quick setup on Linux
+
+Run the Linux helper script to install APT packages and create the
+virtual environment. This mirrors the macOS workflow but uses
+`apt-get` under the hood.
+
+```bash
+./setup_linux.sh
+```
+
+Activate the environment with `source venv/bin/activate` once the
+script completes.
+
+### Quick setup on Windows 10/11
+
+Open PowerShell and execute the Windows setup script. It relies on
+`winget` to fetch Python and Fluidsynth.
+
+```powershell
+./setup_windows.ps1
+```
+
+Afterwards run `./venv/Scripts/Activate.ps1` to enter the environment.
+
 The tests stub out `mido`, `Flask` and `tkinter`, so they are not required to
 run the test suite, but they are necessary for real use.
 

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#----------------------------------------------------------------------
+# setup_linux.sh - Environment setup for Melody-Generator on Linux.
+#
+# This helper installs APT packages and Python dependencies required to
+# run Melody-Generator. It checks for an existing Python 3 installation
+# and only installs a new version when the current one is older than 3.8.
+# A Python virtual environment is created under ./venv.
+#
+# Usage:
+#   ./setup_linux.sh
+#
+# Set the environment variable DRY_RUN=1 to print commands without
+# executing them. This is useful for verifying the commands on systems
+# where sudo privileges might be restricted.
+#----------------------------------------------------------------------
+set -euo pipefail
+
+# run_cmd executes a command or prints it when DRY_RUN is enabled.
+run_cmd() {
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        echo "DRY RUN: $*"
+    else
+        "$@"
+    fi
+}
+
+# verify_linux exits unless running on Linux. The FORCE_LINUX variable
+# can override this to facilitate automated testing on other systems.
+verify_linux() {
+    if [[ "${FORCE_LINUX:-0}" == "1" ]]; then
+        return
+    fi
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        echo "This setup script is intended for Linux." >&2
+        exit 1
+    fi
+}
+
+# check_python ensures Python >=3.8 is installed. If python3 is missing or
+# too old the function installs a newer version using apt-get.
+check_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        local version
+        version=$(python3 --version 2>&1 | awk '{print $2}')
+        local major minor
+        IFS=. read -r major minor _ <<<"$version"
+        if (( major > 3 || (major == 3 && minor >= 8) )); then
+            echo "Found Python $version"
+            return
+        fi
+        echo "Python $version is too old. Installing via apt-get..."
+    else
+        echo "Python3 not found. Installing via apt-get..."
+    fi
+    run_cmd sudo apt-get update
+    run_cmd sudo apt-get install -y python3 python3-venv
+}
+
+# install_pkg installs an APT package unconditionally. The command is
+# wrapped with run_cmd so that DRY_RUN will skip execution.
+install_pkg() {
+    local pkg=$1
+    echo "Installing $pkg via apt-get..."
+    run_cmd sudo apt-get install -y "$pkg"
+}
+
+main() {
+    verify_linux
+
+    check_python
+    install_pkg fluidsynth
+    install_pkg fluid-soundfont-gm
+    install_pkg python3-tk
+    install_pkg libfluidsynth-dev
+
+    if [[ ! -d venv ]]; then
+        echo "Creating Python virtual environment in ./venv"
+        run_cmd python3 -m venv venv
+    fi
+
+    if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        echo "DRY RUN: source venv/bin/activate"
+        echo "DRY RUN: pip install --upgrade pip"
+        echo "DRY RUN: pip install -r requirements.txt"
+        echo "DRY RUN: pip install -e ."
+    else
+        # shellcheck source=/dev/null
+        source venv/bin/activate
+        run_cmd pip install --upgrade pip
+        run_cmd pip install -r requirements.txt
+        run_cmd pip install -e .
+        deactivate
+    fi
+
+    echo "Setup complete. Activate with: source venv/bin/activate"
+}
+
+main "$@"

--- a/setup_windows.ps1
+++ b/setup_windows.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+Setup script for Melody-Generator on Windows 10/11.
+
+.DESCRIPTION
+Installs Python and supporting libraries using winget if necessary, then
+creates a virtual environment in ./venv and installs project dependencies.
+Set the environment variable DRY_RUN=1 to print commands without executing
+them.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+function Run-Command($cmd) {
+    if ($env:DRY_RUN -eq '1') {
+        Write-Host "DRY RUN: $cmd"
+    }
+    else {
+        Invoke-Expression $cmd
+    }
+}
+
+function Ensure-Python {
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        $version = (python --version) -replace 'Python ', ''
+        $parts = $version.Split('.')
+        if ([int]$parts[0] -gt 3 -or ([int]$parts[0] -eq 3 -and [int]$parts[1] -ge 8)) {
+            Write-Host "Found Python $version"
+            return
+        }
+        Write-Host "Python $version too old - installing via winget..."
+    }
+    else {
+        Write-Host 'Python not found - installing via winget...'
+    }
+    Run-Command 'winget install -e --id Python.Python.3'
+}
+
+function Install-Package($id) {
+    Run-Command "winget install -e --id $id"
+}
+
+function main {
+    Ensure-Python
+    Install-Package 'FluidSynth.FluidSynth'
+    Install-Package 'FluidSynth.GeneralMidiSoundFont'
+
+    if (-not (Test-Path 'venv')) {
+        Write-Host 'Creating Python virtual environment in ./venv'
+        Run-Command 'python -m venv venv'
+    }
+
+    if ($env:DRY_RUN -eq '1') {
+        Write-Host 'DRY RUN: .\\venv\\Scripts\\Activate.ps1'
+        Write-Host 'DRY RUN: pip install --upgrade pip'
+        Write-Host 'DRY RUN: pip install -r requirements.txt'
+        Write-Host 'DRY RUN: pip install -e .'
+    }
+    else {
+        .\venv\Scripts\Activate.ps1
+        Run-Command 'pip install --upgrade pip'
+        Run-Command 'pip install -r requirements.txt'
+        Run-Command 'pip install -e .'
+        deactivate
+    }
+    Write-Host 'Setup complete. Activate with: .\\venv\\Scripts\\Activate.ps1'
+}
+
+main

--- a/tests/test_rhythm.py
+++ b/tests/test_rhythm.py
@@ -4,7 +4,6 @@ import importlib
 import sys
 import types
 from pathlib import Path
-import pytest
 
 # Stub out optional dependencies so ``melody_generator`` imports cleanly.
 stub_mido = types.ModuleType("mido")

--- a/tests/test_setup_linux.py
+++ b/tests/test_setup_linux.py
@@ -1,0 +1,57 @@
+"""Tests for the Linux helper script ``setup_linux.sh``.
+
+This module exercises the script in dry-run mode by stubbing ``apt-get`` and
+``python3`` executables. The goal is to ensure Python installation is skipped
+when a modern version exists and required packages are still requested.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_skip_python_install(tmp_path):
+    """Setup script should not install python when version >= 3.8."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "log.txt"
+
+    # Stub apt-get to record invocations for assertions.
+    apt_path = bin_dir / "apt-get"
+    apt_path.write_text(
+        "#!/bin/bash\necho apt-get $@ >> '%s'\n" % log_file
+    )
+    apt_path.chmod(0o755)
+
+    # Provide python3 stub with modern version and basic venv support.
+    py_path = bin_dir / "python3"
+    py_path.write_text(
+        "#!/bin/bash\n"
+        "if [ \"$1\" = --version ]; then echo 'Python 3.9.1'; exit 0; fi\n"
+        "if [ \"$1\" = -m ] && [ \"$2\" = venv ]; then mkdir -p $3/bin; exit 0; fi\n"
+    )
+    py_path.chmod(0o755)
+
+    # Stub pip for dry-run installs.
+    pip_path = bin_dir / "pip"
+    pip_path.write_text("#!/bin/bash\necho pip $@ >> '%s'\n" % log_file)
+    pip_path.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        "PATH": f"{bin_dir}:{env['PATH']}",
+        "FORCE_LINUX": "1",
+        "DRY_RUN": "1",
+    })
+
+    result = subprocess.run(
+        ["bash", "setup_linux.sh"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "apt-get install -y python3 python3-venv" not in result.stdout
+    assert "apt-get install -y fluidsynth" in result.stdout

--- a/tests/test_setup_mac.py
+++ b/tests/test_setup_mac.py
@@ -1,3 +1,12 @@
+"""Tests for the macOS helper script ``setup_mac.sh``.
+
+This module exercises the installation script in dry-run mode. It stubs out
+``brew`` and ``python3`` binaries so that the script can be run without actually
+installing packages. The purpose is to ensure that logic such as skipping the
+Python install when a modern version is present works correctly. Each stub logs
+invocations to ``log.txt`` allowing assertions on the generated commands.
+"""
+
 import os
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add setup scripts for Linux and Windows platforms
- document new helpers in README
- provide linux setup unit test

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68658d7a0d888321a5653902bceac036