### PR TITLE
Improve candidate filtering with NumPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ setup guide, FluidSynth notes and soundfont resources.
 - Variations when motifs repeat so phrases remain interesting.
 - Web interface now previews the generated melody using a WAV rendering created
   with FluidSynth.
+- Batch export helper uses ``ProcessPoolExecutor`` and Celery for parallel
+  generation.
+- Lookup tables and common helpers are memoized with ``functools.lru_cache``
+  to speed up repeated note and scale queries.
 
 # Requirements
 - Python 3.x

--- a/docs/README_ALGORITHM.md
+++ b/docs/README_ALGORITHM.md
@@ -164,6 +164,12 @@ while keeping the algorithm efficient and deterministic.
 - **Vectorized Candidate Selection** – Candidate filtering and sampling now use
   NumPy broadcasting with ``numpy.random.choice`` when possible, eliminating
   Python-level loops for better performance.
+- **Parallel Batch Generation** – Large exports use ``ProcessPoolExecutor`` and
+  the web interface dispatches work to Celery so multiple melodies are created
+  concurrently without blocking the UI.
+- **Caching and Memoization** – ``scale_for_chord`` and ``note_to_midi`` are
+  memoized with ``functools.lru_cache`` and candidate note pools are
+  precomputed at import for faster selection.
 
 ## Candidate Weighting in Depth
 
@@ -197,7 +203,8 @@ toward the distribution of real music.
 ### ONNX Export and Quantization
 
 The helper :func:`melody_generator.sequence_model.export_onnx` exports an LSTM
-to ONNX format. Tools such as ``onnxruntime`` can then apply dynamic
-quantisation, reducing the model to 8‑bit weights for fast CPU inference. The
-exported model expects a sequence of scale‑degree indices and outputs logits for
-the next degree, mirroring ``SequenceModel.predict_logits``.
+to ONNX format. :func:`melody_generator.sequence_model.quantize_onnx_model`
+invokes ``onnxruntime.quantization.quantize_dynamic`` to produce an 8‑bit model
+for CPU inference.  The exported model expects a sequence of scale‑degree
+indices and outputs logits for the next degree, mirroring
+``SequenceModel.predict_logits``.

--- a/melody_generator/batch_generation.py
+++ b/melody_generator/batch_generation.py
@@ -1,0 +1,62 @@
+"""Parallel melody generation helpers.
+
+This module provides a small convenience function for producing many
+melodies concurrently. It offloads each generation call to a worker
+process via :class:`concurrent.futures.ProcessPoolExecutor` so CPU bound
+work scales with the number of available cores.
+
+Example
+-------
+>>> configs = [
+...     {"key": "C", "notes": 8, "chords": ["C", "G"], "motif_length": 4},
+...     {"key": "Dm", "notes": 8, "chords": ["Dm", "A"], "motif_length": 4},
+... ]
+>>> generate_batch(configs, workers=2)
+[["C4", "E4", ...], ["D4", "F4", ...]]
+"""
+
+from __future__ import annotations
+
+import os
+from concurrent.futures import ProcessPoolExecutor
+from typing import Iterable, List, Dict, Any
+
+from . import generate_melody
+
+
+def _generate_single(kwargs: Dict[str, Any]) -> List[str]:
+    """Wrapper used by worker processes to generate one melody."""
+
+    return generate_melody(**kwargs)
+
+
+def generate_batch(
+    configs: Iterable[Dict[str, Any]], *, workers: int | None = None
+) -> List[List[str]]:
+    """Generate multiple melodies in parallel.
+
+    Parameters
+    ----------
+    configs:
+        Iterable of argument dictionaries accepted by :func:`generate_melody`.
+    workers:
+        Optional number of worker processes. When ``None`` the CPU count is
+        used. ``1`` disables multiprocessing and runs serially.
+
+    Returns
+    -------
+    List[List[str]]
+        Each generated melody as a list of note strings.
+    """
+
+    cfg_list = list(configs)
+    if workers is None:
+        workers = os.cpu_count() or 1
+    if workers <= 1:
+        # Fall back to a simple list comprehension so unit tests run without
+        # spawning subprocesses.
+        return [_generate_single(cfg) for cfg in cfg_list]
+
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        futs = [pool.submit(_generate_single, cfg) for cfg in cfg_list]
+        return [f.result() for f in futs]

--- a/tests/test_batch_generation.py
+++ b/tests/test_batch_generation.py
@@ -1,0 +1,82 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_generate_batch_uses_process_pool(monkeypatch):
+    """``generate_batch`` should create a ``ProcessPoolExecutor`` when workers>1."""
+
+    # Provide lightweight stubs so the module imports without optional dependencies
+    stub_mido = types.ModuleType("mido")
+
+    class DummyMidiFile:
+        def __init__(self, *a, **k):
+            self.tracks = []
+
+        def save(self, _):
+            pass
+
+    stub_mido.Message = lambda *a, **k: None
+    stub_mido.MidiFile = DummyMidiFile
+    stub_mido.MidiTrack = list
+    stub_mido.MetaMessage = lambda *a, **k: None
+    stub_mido.bpm2tempo = lambda bpm: bpm
+    monkeypatch.setitem(sys.modules, "mido", stub_mido)
+
+    tk_stub = types.ModuleType("tkinter")
+    tk_stub.filedialog = types.ModuleType("filedialog")
+    tk_stub.messagebox = types.ModuleType("messagebox")
+    tk_stub.ttk = types.ModuleType("ttk")
+    monkeypatch.setitem(sys.modules, "tkinter", tk_stub)
+    monkeypatch.setitem(sys.modules, "tkinter.filedialog", tk_stub.filedialog)
+    monkeypatch.setitem(sys.modules, "tkinter.messagebox", tk_stub.messagebox)
+    monkeypatch.setitem(sys.modules, "tkinter.ttk", tk_stub.ttk)
+
+    calls = {}
+
+    class DummyExec:
+        def __init__(self, max_workers=None):
+            calls["workers"] = max_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def submit(self, fn, cfg):
+            class DummyFut:
+                def result(self_inner):
+                    return fn(cfg)
+
+            return DummyFut()
+
+    batch = importlib.import_module("melody_generator.batch_generation")
+
+    monkeypatch.setattr(batch, "ProcessPoolExecutor", DummyExec)
+    monkeypatch.setattr(
+        batch, "generate_melody", lambda **kw: [kw["key"]] * kw["num_notes"]
+    )
+
+    configs = [
+        {
+            "key": "C",
+            "num_notes": 2,
+            "chord_progression": ["C"],
+            "motif_length": 1,
+        },
+        {
+            "key": "D",
+            "num_notes": 2,
+            "chord_progression": ["D"],
+            "motif_length": 1,
+        },
+    ]
+
+    res = batch.generate_batch(configs, workers=2)
+
+    assert calls["workers"] == 2
+    assert res == [["C", "C"], ["D", "D"]]

--- a/tests/test_memoization.py
+++ b/tests/test_memoization.py
@@ -45,3 +45,29 @@ def test_canonical_chord_cache_hits():
     mod.canonical_chord("Dm")
     info_after = mod.canonical_chord.cache_info()
     assert info_after.hits >= info_before.hits + 1
+
+
+def test_scale_for_chord_cache_hits():
+    """``scale_for_chord`` should memoize results via ``lru_cache``."""
+
+    info_before = mod.scale_for_chord.cache_info()
+    mod.scale_for_chord("C", "G")
+    mod.scale_for_chord("C", "G")
+    info_after = mod.scale_for_chord.cache_info()
+    assert info_after.hits >= info_before.hits + 1
+
+
+def test_note_to_midi_cache_hits():
+    """Repeated note conversions should trigger cache hits."""
+
+    info_before = mod.note_to_midi.cache_info()
+    mod.note_to_midi("C4")
+    mod.note_to_midi("C4")
+    info_after = mod.note_to_midi.cache_info()
+    assert info_after.hits >= info_before.hits + 1
+
+
+def test_candidate_cache_preloaded():
+    """Importing the module should populate ``_CANDIDATE_CACHE``."""
+
+    assert mod._CANDIDATE_CACHE

--- a/tests/test_rhythm_engine.py
+++ b/tests/test_rhythm_engine.py
@@ -4,6 +4,8 @@ import importlib
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 rhythm = importlib.import_module("melody_generator.rhythm_engine")
@@ -20,4 +22,21 @@ def test_rhythm_generator_custom_transitions():
 
     gen = rhythm.RhythmGenerator({0.5: {0.5: 1.0}}, start=0.5)
     assert gen.generate(3) == [0.5, 0.5, 0.5]
+
+
+def test_generate_uses_numpy_choice(monkeypatch):
+    """``RhythmGenerator.generate`` should call ``numpy.random.choice`` when available."""
+    if rhythm.np is None:
+        pytest.skip("numpy not available")
+
+    called = {"flag": False}
+
+    def fake_choice(seq, p=None):
+        called["flag"] = True
+        return seq[0]
+
+    monkeypatch.setattr(rhythm.np.random, "choice", fake_choice)
+    gen = rhythm.RhythmGenerator(start=0.25)
+    gen.generate(2)
+    assert called["flag"]
 


### PR DESCRIPTION
## Summary
- vectorize candidate filtering in `generate_melody`
- use `numpy.random.choice` in `RhythmGenerator.generate`
- test that rhythm generation calls NumPy choice when available
- add ONNX export + quantization helper
- parallelize batch generation with `ProcessPoolExecutor`
- dispatch Flask requests to Celery tasks for non-blocking handling
- memoize `scale_for_chord` and `note_to_midi` with `lru_cache`
- preload candidate pools during import

## Testing
- `ruff check .`
- `pytest -q`