### PR TITLE
Fix refine_with_fmd handling of short melodies

### DIFF
--- a/melody_generator/feedback.py
+++ b/melody_generator/feedback.py
@@ -91,6 +91,12 @@ def refine_with_fmd(
     if not melody:
         raise ValueError("melody must not be empty")
 
+    if len(melody) < 3:
+        # With fewer than three notes there are no interior positions to
+        # modify while keeping the first and last notes fixed, so simply
+        # return the melody unchanged.
+        return melody
+
     size = max(1, int(len(melody) * 0.05))
     best_score = compute_fmd(melody)
 

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -58,3 +58,14 @@ def test_refine_with_fmd_improves_distance():
     after = fb.compute_fmd(refined)
     assert after <= before
 
+
+def test_refine_with_fmd_short_sequences_return_input():
+    """Sequences with fewer than three notes should not be modified."""
+
+    fb = importlib.import_module("melody_generator.feedback")
+
+    one = ["C4"]
+    two = ["C4", "E4"]
+    assert fb.refine_with_fmd(one.copy(), "C", ["C"], 4) == one
+    assert fb.refine_with_fmd(two.copy(), "C", ["C"], 4) == two
+


### PR DESCRIPTION
## Summary
- avoid ValueError in `refine_with_fmd` when melody has fewer than three notes
- test small sequences remain unchanged

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868986d02f8832184be989c13a5c7bb