### PR TITLE
Fix note_to_midi clamp

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -674,6 +674,8 @@ def note_to_midi(note: str) -> int:
 
     @param note (str): Note name including octave.
     @returns int: MIDI note number ``0-127``.
+    Note values outside the standard range are clamped to keep the
+    resulting MIDI pitch valid.
     """
     # Extract the note name and octave using a strict pattern.  The pattern
     # ensures the note consists of a letter with an optional accidental
@@ -715,9 +717,11 @@ def note_to_midi(note: str) -> int:
         logging.error(f"Note {note_name} not recognized.")
         raise
 
-    # MIDI note number is calculated relative to C0 at index 12
+    # MIDI note number is calculated relative to C0 at index 12. The resulting
+    # value may fall outside the ``0-127`` range when the octave is extreme,
+    # so clamp it to keep the result valid for standard MIDI files.
     midi_val = note_idx + (octave * 12)
-    return midi_val
+    return max(0, min(127, midi_val))
 
 
 def midi_to_note(midi_note: int) -> str:

--- a/tests/test_note_to_midi.py
+++ b/tests/test_note_to_midi.py
@@ -51,5 +51,10 @@ def test_multi_digit_octaves():
     This ensures ``note_to_midi`` handles values like ``C10`` or ``Gb11`` by
     reading all trailing digits instead of only the last character.
     """
-    assert note_to_midi('C10') == 132
-    assert note_to_midi('Gb11') == 150
+    assert note_to_midi('C10') == 127  # values above 127 are clamped
+    assert note_to_midi('Gb11') == 127
+
+
+def test_negative_octaves_clamped():
+    """Notes below MIDI 0 clamp to 0."""
+    assert note_to_midi('C-2') == 0


### PR DESCRIPTION
## Summary
- clamp `note_to_midi` results to the valid 0-127 MIDI range
- expand docstring explaining clamping
- update tests accordingly and check negative octave handling

## Testing
- `pytest tests/test_note_to_midi.py::test_multi_digit_octaves tests/test_note_to_midi.py::test_negative_octaves_clamped -q`
- `pytest -q`
- `ruff check`