### PR TITLE
Add instrument validation to Flask UI

### DIFF
--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -231,6 +231,16 @@ def index():
         motif_length = int(request.form.get('motif_length') or 4)
         base_octave = int(request.form.get('base_octave') or 4)
         instrument = request.form.get('instrument') or 'Piano'
+        # Validate the selected instrument against the known General MIDI
+        # mapping. Unknown values likely mean the form was tampered with.
+        if instrument not in INSTRUMENTS:
+            flash("Unknown instrument")
+            return render_template(
+                'index.html',
+                scale=sorted(SCALE.keys()),
+                instruments=INSTRUMENTS.keys(),
+                styles=STYLE_VECTORS.keys(),
+            )
         harmony = bool(request.form.get('harmony'))
         random_rhythm = bool(request.form.get('random_rhythm'))
         counterpoint = bool(request.form.get('counterpoint'))

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -181,6 +181,28 @@ def test_invalid_chord_flash():
     assert b"Unknown chord" in resp.data
 
 
+def test_invalid_instrument_flash():
+    """Posting an instrument not in ``INSTRUMENTS`` shows an error."""
+
+    client = app.test_client()
+
+    resp = client.post(
+        "/",
+        data={
+            "key": "C",
+            "chords": "C",
+            "bpm": "120",
+            "timesig": "4/4",
+            "notes": "8",
+            "motif_length": "4",
+            "base_octave": "4",
+            "instrument": "Banjo",
+        },
+    )
+
+    assert b"Unknown instrument" in resp.data
+
+
 def test_include_chords_flag():
     """Setting the ``include_chords`` checkbox should be accepted."""
     client = app.test_client()


### PR DESCRIPTION
## Summary
- flash an error when instrument selection is unknown
- add regression test covering invalid instrument case

## Testing
- `ruff check .`
- `PYTHONPATH=$(pwd) pytest -q`