### PR TITLE
Handle invalid random rhythm length

### DIFF
--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -650,9 +650,17 @@ def generate_random_rhythm_pattern(length: int = 3) -> List[float]:
     small variation may be applied after the first full repetition by replacing
     one value with an eighth note (``0.125``).
 
-    @param length (int): Number of durations to produce.
+    ``ValueError`` is raised when ``length`` is ``0`` or negative so callers
+    cannot request an empty pattern.
+
+    @param length (int): Number of durations to produce. Must be positive.
     @returns List[float]: Pattern of note lengths in fractions of a whole note.
     """
+
+    if length <= 0:
+        # Guard against nonsensical or empty requests. The rhythm engine relies
+        # on a positive number of durations to schedule MIDI events.
+        raise ValueError("length must be positive")
 
     allowed = [0.25, 0.5, 0.75, 0.125, 0.0625, 0]
     motifs = [

--- a/tests/test_rhythm.py
+++ b/tests/test_rhythm.py
@@ -4,6 +4,7 @@ import importlib
 import sys
 import types
 from pathlib import Path
+import pytest
 
 # Stub out optional dependencies so ``melody_generator`` imports cleanly.
 stub_mido = types.ModuleType("mido")
@@ -35,3 +36,17 @@ def test_generate_random_rhythm_pattern_valid_lengths():
     allowed = {0.25, 0.5, 0.75, 0.125, 0.0625, 0}
     assert len(pattern) == length
     assert all(val in allowed for val in pattern)
+
+
+def test_generate_random_rhythm_pattern_zero_length():
+    """A ``length`` of ``0`` should raise ``ValueError``."""
+
+    with pytest.raises(ValueError):
+        melody_generator.generate_random_rhythm_pattern(0)
+
+
+def test_generate_random_rhythm_pattern_negative_length():
+    """Negative ``length`` values are invalid and should raise ``ValueError``."""
+
+    with pytest.raises(ValueError):
+        melody_generator.generate_random_rhythm_pattern(-5)


### PR DESCRIPTION
## Summary
- raise `ValueError` from `generate_random_rhythm_pattern` when length is non-positive
- clarify docstring for new check
- test zero and negative lengths raising an error

## Testing
- `ruff check .`
- `pytest -q`