### PR TITLE
Add MIDI humanization toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ musician's perspective
 - Cross-platform setup scripts now ship with executable permissions for one-step
   installation.
 - Dynamic velocity in the MIDI output for a more natural sound.
+- Optional performance humanization adds slight timing and velocity
+  variations. This can be disabled for fully quantized output.
 - Expanded rhythmic patterns including eighth- and sixteenth-note figures.
 - GUI button to reload saved preferences at any time.
 - GUI can preview the generated melody before saving.
@@ -111,11 +113,13 @@ melody-generator \
   --instrument 0 \
   --soundfont /path/to/font.sf2 \
   --output song.mid \
+  --no-humanize \
   --harmony --counterpoint --harmony-lines 1
 ```
 
 This command creates `song.mid` with one harmony line and an additional counterpoint track.
 The `--instrument` option selects the General MIDI program number used for the melody.
+Pass `--no-humanize` if you want deterministic timing so events align exactly on the beat.
 Use `--play` to automatically preview the file once it is written.
 
 ### GUI
@@ -128,6 +132,7 @@ melody-generator
 
 1. Choose a key, BPM, time signature and chord progression.
 2. Check the **Harmony** or **Counterpoint** boxes to add extra tracks.
+3. Leave **Humanize Performance** enabled for natural timing or untick it for strict quantization.
 3. Click **Preview Melody** to hear the result without saving.
 4. Click **Generate Melody** and select where to save the MIDI file.
 
@@ -142,11 +147,12 @@ python -m melody_generator.web_gui
 
 1. Open `http://localhost:5000` in your browser.
 2. Fill out the form just like the GUI version.
-3. Submit to preview and download the generated file.
-4. Set the `FLASK_SECRET` environment variable to a persistent secret. If it
+3. Keep **Humanize Performance** checked for more realism or uncheck for exact timing.
+4. Submit to preview and download the generated file.
+5. Set the `FLASK_SECRET` environment variable to a persistent secret. If it
    is not provided a random key is generated on startup and a warning is
    logged.
-5. Optionally set `FLASK_DEBUG=1` to enable Flask debug mode during
+6. Optionally set `FLASK_DEBUG=1` to enable Flask debug mode during
    development.
 
 

--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -1745,7 +1745,9 @@ def run_cli() -> None:
     The ``--soundfont`` argument allows supplying a custom ``.sf2`` file
     used when previewing the result via ``--play``. ``--enable-ml`` loads
     a small LSTM so note weighting uses learned statistics. ``--style``
-    selects a predefined style embedding.
+    selects a predefined style embedding.  Pass ``--no-humanize`` to
+    disable timing adjustments so output remains fully quantized for
+    deterministic tests or sequencer import.
 
     @returns None: Exits via ``sys.exit`` on failure.
     """

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -118,6 +118,7 @@ class MelodyGeneratorGUI:
 
         self.rhythm_pattern: Optional[List[float]] = None
         self.ml_var = tk.BooleanVar(value=False)
+        self.humanize_var = tk.BooleanVar(value=True)
         self.style_var = tk.StringVar(value="")
         self.styles = sorted(STYLE_VECTORS.keys())
 
@@ -452,42 +453,48 @@ class MelodyGeneratorGUI:
             variable=self.chords_same_var,
         ).grid(row=14, column=0, columnspan=2)
 
+        ttk.Checkbutton(
+            frame,
+            text="Humanize Performance",
+            variable=self.humanize_var,
+        ).grid(row=15, column=0, columnspan=2)
+
         # Randomize buttons
         ttk.Button(
             frame,
             text="Randomize Chords",
             command=self._randomize_chords,
-        ).grid(row=15, column=0, columnspan=2, pady=(5, 0))
+        ).grid(row=16, column=0, columnspan=2, pady=(5, 0))
         ttk.Button(
             frame,
             text="Randomize Rhythm",
             command=self._randomize_rhythm,
-        ).grid(row=16, column=0, columnspan=2, pady=(5, 0))
+        ).grid(row=17, column=0, columnspan=2, pady=(5, 0))
 
         ttk.Button(
             frame,
             text="Load Preferences",
             command=self._load_preferences,
-        ).grid(row=17, column=0, columnspan=2, pady=(5, 0))
+        ).grid(row=18, column=0, columnspan=2, pady=(5, 0))
 
         ttk.Button(
             frame,
             text="Preview Melody",
             command=self._preview_button_click,
-        ).grid(row=18, column=0, columnspan=2, pady=(5, 0))
+        ).grid(row=19, column=0, columnspan=2, pady=(5, 0))
         self.preview_notice = ttk.Label(
             frame,
             text="",
             foreground="yellow",
         )
-        self.preview_notice.grid(row=18, column=2, sticky="w")
+        self.preview_notice.grid(row=19, column=2, sticky="w")
 
         # Generate button
         ttk.Button(
             frame,
             text="Generate Melody",
             command=self._generate_button_click,
-        ).grid(row=19, column=0, columnspan=2, pady=10)
+        ).grid(row=20, column=0, columnspan=2, pady=10)
 
         self.theme_var = tk.BooleanVar(value=self.dark_mode)
         ttk.Checkbutton(
@@ -495,7 +502,7 @@ class MelodyGeneratorGUI:
             text="Toggle Dark Mode",
             command=self._toggle_theme,
             variable=self.theme_var,
-        ).grid(row=20, column=0, columnspan=2, pady=(5, 0))
+        ).grid(row=21, column=0, columnspan=2, pady=(5, 0))
 
         # Apply persisted settings if available
         if self.load_settings is not None:
@@ -606,6 +613,9 @@ class MelodyGeneratorGUI:
                 ),
                 chords_separate=not self.chords_same_var.get(),
                 program=INSTRUMENTS.get(self.instrument_var.get(), 0),
+                humanize=self.humanize_var.get()
+                if hasattr(self, "humanize_var")
+                else True,
             )
             messagebox.showinfo("Success", f"MIDI file saved to {output_file}")
             if self.save_settings is not None and messagebox.askyesno(
@@ -708,6 +718,9 @@ class MelodyGeneratorGUI:
             chord_progression=chords if self.include_chords_var.get() else None,
             chords_separate=not self.chords_same_var.get(),
             program=INSTRUMENTS.get(self.instrument_var.get(), 0),
+            humanize=self.humanize_var.get()
+            if hasattr(self, "humanize_var")
+            else True,
         )
         playback_succeeded = False
         try:
@@ -827,6 +840,7 @@ class MelodyGeneratorGUI:
             "chords_same": self.chords_same_var.get(),
             "instrument": self.instrument_var.get(),
             "soundfont": self.soundfont_var.get(),
+            "humanize": self.humanize_var.get(),
         }
 
     def _apply_settings(self, settings: Dict) -> None:
@@ -859,6 +873,8 @@ class MelodyGeneratorGUI:
             self.include_chords_var.set(settings["include_chords"])
         if "chords_same" in settings:
             self.chords_same_var.set(settings["chords_same"])
+        if "humanize" in settings:
+            self.humanize_var.set(settings["humanize"])
         if "instrument" in settings and settings["instrument"] in INSTRUMENTS:
             self.instrument_var.set(settings["instrument"])
         if "soundfont" in settings:

--- a/melody_generator/templates/index.html
+++ b/melody_generator/templates/index.html
@@ -46,6 +46,7 @@
     Harmony lines: <input type="number" name="harmony_lines" value="0"><br>
     <label><input type="checkbox" name="include_chords" value="1"> Include chord track</label><br>
     <label><input type="checkbox" name="chords_same" value="1"> Merge chords with melody</label><br>
+    <label><input type="checkbox" name="humanize" value="1" checked> Humanize performance</label><br>
     <label><input type="checkbox" name="random_rhythm" value="1"> Random rhythm</label><br>
     <input type="submit" value="Generate">
   </form>

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -131,6 +131,7 @@ def _generate_preview(
     enable_ml: bool,
     style: str | None,
     chords: List[str],
+    humanize: bool,
 ) -> tuple[str, str]:
     """Return ``(audio_b64, midi_b64)`` for the requested melody."""
 
@@ -176,6 +177,7 @@ def _generate_preview(
         chord_progression=chords if include_chords else None,
         chords_separate=not chords_same,
         program=INSTRUMENTS.get(instrument, 0),
+        humanize=humanize,
     )
 
     wav_tmp = NamedTemporaryFile(suffix=".wav", delete=False)
@@ -251,6 +253,7 @@ def index():
         harmony_lines = int(request.form.get('harmony_lines') or 0)
         include_chords = bool(request.form.get('include_chords'))
         chords_same = bool(request.form.get('chords_same'))
+        humanize = bool(request.form.get('humanize', '1'))
         enable_ml = bool(request.form.get('enable_ml'))
         style = request.form.get('style') or None
 
@@ -316,6 +319,7 @@ def index():
             harmony_lines=harmony_lines,
             include_chords=include_chords,
             chords_same=chords_same,
+            humanize=humanize,
             enable_ml=enable_ml,
             style=style,
             chords=chords,

--- a/tests/test_humanize_flag.py
+++ b/tests/test_humanize_flag.py
@@ -1,3 +1,10 @@
+"""Unit tests validating the new humanization toggle.
+
+The module stubs out the ``mido`` dependency so tests can run without
+writing actual MIDI files. It reloads ``melody_generator`` with these
+stubs and verifies that events are unchanged when ``humanize=False``.
+"""
+
 import importlib
 import sys
 import types
@@ -48,6 +55,10 @@ def _setup_module():
 
 def test_no_humanize_preserves_events(tmp_path, monkeypatch):
     """Events remain unaltered when ``humanize`` is ``False``."""
+    # The DummyFile tracks list will hold the messages written by
+    # ``create_midi_file``. By calling the function twice—once with
+    # ``humanize`` disabled and once enabled—we can compare the resulting
+    # timings to confirm jitter only applies when requested.
     mod, DummyFile = _setup_module()
 
     def fake_humanize(msgs):

--- a/tests/test_humanize_flag.py
+++ b/tests/test_humanize_flag.py
@@ -1,7 +1,6 @@
 import importlib
 import sys
 import types
-from pathlib import Path
 
 
 def _setup_module():

--- a/tests/test_humanize_flag.py
+++ b/tests/test_humanize_flag.py
@@ -1,0 +1,72 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _setup_module():
+    """Reload melody_generator with stubbed dependencies."""
+    stub_mido = types.ModuleType("mido")
+
+    class Msg:
+        def __init__(self, type: str, **kw) -> None:
+            self.type = type
+            self.time = kw.get("time", 0)
+            self.velocity = kw.get("velocity")
+            self.note = kw.get("note")
+            self.program = kw.get("program")
+
+    class DummyFile:
+        last_instance = None
+
+        def __init__(self, *a, **k) -> None:
+            self.tracks = []
+            DummyFile.last_instance = self
+
+        def save(self, _p: str) -> None:
+            pass
+
+    stub_mido.Message = Msg
+    stub_mido.MidiFile = DummyFile
+    stub_mido.MidiTrack = list
+    stub_mido.MetaMessage = lambda *a, **k: Msg("meta", **k)
+    stub_mido.bpm2tempo = lambda bpm: bpm
+    sys.modules["mido"] = stub_mido
+
+    tk_stub = types.ModuleType("tkinter")
+    tk_stub.filedialog = types.ModuleType("filedialog")
+    tk_stub.messagebox = types.ModuleType("messagebox")
+    tk_stub.ttk = types.ModuleType("ttk")
+    sys.modules.setdefault("tkinter", tk_stub)
+    sys.modules.setdefault("tkinter.filedialog", tk_stub.filedialog)
+    sys.modules.setdefault("tkinter.messagebox", tk_stub.messagebox)
+    sys.modules.setdefault("tkinter.ttk", tk_stub.ttk)
+
+    if "melody_generator" in sys.modules:
+        del sys.modules["melody_generator"]
+    return importlib.import_module("melody_generator"), DummyFile
+
+
+def test_no_humanize_preserves_events(tmp_path, monkeypatch):
+    """Events remain unaltered when ``humanize`` is ``False``."""
+    mod, DummyFile = _setup_module()
+
+    def fake_humanize(msgs):
+        for m in msgs:
+            m.time += 99
+
+    monkeypatch.setattr(mod, "humanize_events", fake_humanize)
+
+    melody = ["C4", "D4"]
+    out = tmp_path / "a.mid"
+    mod.create_midi_file(melody, 120, (4, 4), str(out), pattern=[0.25], humanize=False)
+    base_times = [m.time for m in DummyFile.last_instance.tracks[0]]
+
+    out2 = tmp_path / "b.mid"
+    mod.create_midi_file(melody, 120, (4, 4), str(out2), pattern=[0.25], humanize=True)
+    jitter_times = [m.time for m in DummyFile.last_instance.tracks[0]]
+
+    assert base_times != jitter_times
+    diffs = [j - b for j, b in zip(jitter_times, base_times)]
+    assert any(d == 99 for d in diffs)
+    assert all(b <= j for b, j in zip(base_times, jitter_times))


### PR DESCRIPTION
## Summary
- expose a `humanize` flag in `create_midi_file` for optional timing jitter
- add `--no-humanize` CLI flag
- add GUI checkbox and web interface checkbox for humanization
- update web API and preview task to forward the flag
- test that disabling humanization leaves MIDI events unchanged

## Testing
- `pytest -q`