### PR TITLE
Fix CI by pinning numpy and updating GUI test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "mido==1.2.10",
     "Flask",
     "pyfluidsynth",
+    "numpy<2",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mido==1.2.10
 Flask
 pyfluidsynth
+numpy<2

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -459,6 +459,9 @@ def test_delay_arguments_match_preview_parameters(monkeypatch):
         "harmony_lines": 0,
         "include_chords": False,
         "chords_same": False,
+        # The web GUI forwards the humanize option to ``create_midi_file``.
+        # When the checkbox is unchecked the default ``False`` should be sent.
+        "humanize": False,
         "enable_ml": False,
         "style": None,
         "chords": ["C"],


### PR DESCRIPTION
## Summary
- pin numpy in `pyproject.toml` and `requirements.txt` for Python 3.8 wheels
- update `test_web_gui` to expect the humanize flag

## Testing
- `ruff check .`
- `pytest -q`