### PR TITLE
Add augment_sequences tests and validation

### DIFF
--- a/melody_generator/augmentation.py
+++ b/melody_generator/augmentation.py
@@ -79,10 +79,33 @@ def augment_sequences(
 ) -> List[List[int]]:
     """Return augmented copies of ``sequences``.
 
-    Each input sequence is transposed by every value in ``transpose_range``.
-    When ``invert`` is ``True`` the inverted form is added as well using the
-    first pitch as the pivot.
+    Each sequence is duplicated for every value in ``transpose_range``. When
+    ``invert`` is ``True`` the inverted form is appended alongside each
+    transposition using the sequence's first note as the pivot.
+
+    Parameters
+    ----------
+    sequences:
+        Iterable of pitch sequences to augment. Must not be empty.
+    transpose_range:
+        Collection of semitone offsets applied to each sequence. Defaults to
+        ``range(-2, 3)`` yielding five transpositions.
+    invert:
+        When ``True`` append an inverted version for each transposition.
+
+    Returns
+    -------
+    list[list[int]]
+        Augmented pitch sequences.
+
+    Raises
+    ------
+    ValueError
+        If ``sequences`` is empty.
     """
+    sequences = list(sequences)
+    if not sequences:
+        raise ValueError("sequences must not be empty")
 
     augmented: List[List[int]] = []
     for seq in sequences:

--- a/tests/test_augmentation_helpers.py
+++ b/tests/test_augmentation_helpers.py
@@ -1,0 +1,83 @@
+"""Unit tests for the ``augment_sequences`` helper.
+
+This module verifies that data augmentation correctly generates transposed and
+optionally inverted copies of input pitch sequences.  It also checks error
+handling when no sequences are provided and that custom transposition ranges are
+honoured.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Provide minimal stubs so the package imports without optional dependencies.
+mido_stub = types.ModuleType("mido")
+mido_stub.Message = object
+mido_stub.MidiFile = object
+mido_stub.MidiTrack = list
+mido_stub.MetaMessage = lambda *a, **kw: object()
+mido_stub.bpm2tempo = lambda bpm: bpm
+
+tk_stub = types.ModuleType("tkinter")
+tk_stub.filedialog = types.ModuleType("filedialog")
+tk_stub.messagebox = types.ModuleType("messagebox")
+tk_stub.ttk = types.ModuleType("ttk")
+
+
+@pytest.fixture(autouse=True)
+def _patch_deps(monkeypatch):
+    """Insert stubs and reload the augmentation module for a clean import."""
+
+    monkeypatch.setitem(sys.modules, "mido", mido_stub)
+    monkeypatch.setitem(sys.modules, "tkinter", tk_stub)
+    monkeypatch.setitem(sys.modules, "tkinter.filedialog", tk_stub.filedialog)
+    monkeypatch.setitem(sys.modules, "tkinter.messagebox", tk_stub.messagebox)
+    monkeypatch.setitem(sys.modules, "tkinter.ttk", tk_stub.ttk)
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    global aug
+    aug = importlib.reload(importlib.import_module("melody_generator.augmentation"))
+
+
+def test_augment_sequences_default_transposes_and_inverts():
+    """Default parameters should create five transpositions and their inversions."""
+
+    seq = [60, 62]
+
+    result = aug.augment_sequences([seq])
+
+    assert len(result) == 10
+
+    for t in range(-2, 3):
+        assert aug.transpose_sequence(seq, t) in result
+
+    inverted = aug.invert_sequence(seq, seq[0])
+    assert result.count(inverted) == 5
+
+
+def test_augment_sequences_empty_input_error():
+    """Passing an empty list of sequences should raise ``ValueError``."""
+
+    with pytest.raises(ValueError):
+        aug.augment_sequences([])
+
+
+def test_augment_sequences_custom_transpose_range():
+    """User-supplied ranges must control the transpositions applied."""
+
+    seq = [60]
+    tr = [0, 12]
+
+    result = aug.augment_sequences([seq], transpose_range=tr)
+
+    expected = []
+    for t in tr:
+        expected.append(aug.transpose_sequence(seq, t))
+        expected.append(aug.invert_sequence(seq, seq[0]))
+
+    assert result == expected


### PR DESCRIPTION
## Summary
- validate input to `augment_sequences` and document parameters
- add comprehensive unit tests for `augment_sequences`

## Testing
- `ruff check .`
- `pytest -q`