### PR TITLE
Add comprehensive docstrings to analysis modules

### DIFF
--- a/melody_generator/performance.py
+++ b/melody_generator/performance.py
@@ -1,4 +1,23 @@
-"""Performance helpers and optional profiling utilities."""
+"""Performance helpers and optional profiling utilities.
+
+This file defines ``compute_base_weights`` which generates Markov-style
+transition weights for melody intervals and a :func:`profile` context manager
+for collecting ``cProfile`` statistics.  ``NumPy`` and ``Numba`` are detected
+at runtime so the algorithms can accelerate themselves transparently when
+available without adding hard dependencies.
+
+Example
+-------
+>>> compute_base_weights([2, 4], [True, False], 2)
+[1.7999999999999998, 0.48]
+
+Design Notes
+------------
+- The Numba ``jit`` function is optional; pure Python fallbacks are used when
+  the import fails so unit tests remain fast.
+- Transition and similarity lookup tables are stored as arrays for speed but
+  plain lists are substituted when ``numpy`` is missing.
+"""
 
 from __future__ import annotations
 

--- a/melody_generator/tension.py
+++ b/melody_generator/tension.py
@@ -1,4 +1,25 @@
-"""Helpers for computing and applying musical tension."""
+"""Helpers for computing and applying musical tension.
+
+This module defines lightweight utilities used to weight candidate notes
+based on their perceived tension relative to the previous pitch.  The
+functions here provide a simple mapping from interval sizes to tension
+values and expose helpers for adjusting selection weights during melody
+generation.
+
+Example
+-------
+>>> weights = [1.0, 1.0, 1.0]
+>>> tens = [0.2, 0.8, 0.4]
+>>> apply_tension_weights(weights, tens, 0.5)
+[0.8333333333333334, 0.5555555555555556, 1.0]
+
+Design Notes
+------------
+- ``numpy`` is optional and the routines fall back to pure Python when the
+  library is unavailable.
+- The interval-to-tension mapping is intentionally coarse so the computation
+  remains fast and easily adjustable.
+"""
 
 from __future__ import annotations
 

--- a/melody_generator/voice_leading.py
+++ b/melody_generator/voice_leading.py
@@ -1,4 +1,24 @@
-"""Utilities for detecting basic counterpoint issues."""
+"""Utilities for detecting basic counterpoint issues.
+
+This module contains helpers used by the melody generator to discourage
+problematic motion such as parallel fifths or octaves.  The primary
+functions are ``counterpoint_penalty`` and ``parallel_fifths_mask`` which
+return weighting adjustments and boolean masks respectively.  All inputs are
+provided as note names (e.g. ``"C4"``) so the routines remain agnostic to the
+rest of the system.
+
+Example
+-------
+>>> counterpoint_penalty("C4", "D4", prev_dir=1, prev_interval=7)
+0.2
+
+Design Notes
+------------
+- ``numpy`` is used for vectorized computation when available but the code
+  falls back to pure Python for simplicity and testability.
+- Only minimal music theory is encoded—these checks are meant as gentle
+  nudges rather than strict rules.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document tension helpers with usage notes
- expand performance utilities description and example
- flesh out voice-leading module documentation

## Testing
- `ruff check .`
- `pytest -q`