### PR TITLE
Normalize API inputs for key and chords

### DIFF
--- a/melody_generator/midi_io.py
+++ b/melody_generator/midi_io.py
@@ -17,7 +17,13 @@ from typing import List, Optional, Tuple
 import mido
 from mido import Message, MidiFile, MidiTrack
 
-from . import CHORDS, generate_rhythm, humanize_events, note_to_midi
+from . import (
+    CHORDS,
+    canonical_chord,
+    generate_rhythm,
+    humanize_events,
+    note_to_midi,
+)
 
 __all__ = ["create_midi_file", "_open_default_player"]
 
@@ -35,10 +41,19 @@ def create_midi_file(
     program: int = 0,
     humanize: bool = True,
 ) -> None:
-    """Write ``melody`` to ``output_file`` as a MIDI file."""
+    """Write ``melody`` to ``output_file`` as a MIDI file.
+
+    Chord names supplied via ``chord_progression`` are canonicalised using
+    :func:`canonical_chord` so case-insensitive input is accepted. Unknown
+    chords raise ``ValueError`` before any MIDI events are created.
+    """
 
     if chord_progression is not None and not chord_progression:
         raise ValueError("chord_progression must contain at least one chord")
+    # Normalize chord names so callers can pass lowercase values. Unknown names
+    # trigger ``ValueError`` here before any MIDI events are generated.
+    if chord_progression is not None:
+        chord_progression = [canonical_chord(ch) for ch in chord_progression]
     valid_denoms = {1, 2, 4, 8, 16}
     if (time_signature[0] <= 0 or time_signature[1] <= 0 or
             time_signature[1] not in valid_denoms):

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -642,3 +642,29 @@ def test_generate_melody_custom_rhythm_generator():
     generate_melody("C", 4, ["C"], motif_length=2, rhythm_generator=gen)
     assert gen.called == 1
 
+
+def test_generate_melody_accepts_lowercase():
+    """Lowercase key and chord names are canonicalised automatically."""
+
+    melody = generate_melody("c", 4, ["c", "am"], motif_length=2)
+    assert len(melody) == 4
+
+
+def test_create_midi_file_accepts_lowercase(tmp_path):
+    """Chord names in lowercase should be processed without errors."""
+
+    melody = ["C4"] * 4
+    out = tmp_path / "lower.mid"
+    create_midi_file(
+        melody,
+        120,
+        (4, 4),
+        str(out),
+        pattern=[0.25],
+        chord_progression=["c", "g"],
+    )
+
+    mid = DummyMidiFile.last_instance
+    assert mid is not None
+    assert len(mid.tracks) == 2
+


### PR DESCRIPTION
## Summary
- canonicalise key and chord inputs within `generate_melody`
- canonicalise chord names within `create_midi_file`
- accept lowercase keys and chords in melody API tests

## Testing
- `ruff check .`
- `pytest -q`