### PR TITLE
Validate worker count in generate_batch

### DIFF
--- a/melody_generator/batch_generation.py
+++ b/melody_generator/batch_generation.py
@@ -42,8 +42,8 @@ def generate_batch(
     workers:
         Optional number of worker processes. When ``None`` the CPU count is
         used. ``1`` disables multiprocessing and runs serially. ``ValueError``
-        is raised when a negative value is supplied so callers receive
-        immediate feedback about invalid input.
+        is raised when ``workers`` is ``0`` or a negative value so callers
+        receive immediate feedback about invalid input.
 
     Returns
     -------
@@ -52,10 +52,11 @@ def generate_batch(
     """
 
     cfg_list = list(configs)
-    if workers is not None and workers < 0:
-        # Negative worker counts are nonsensical. Reject them early so callers
-        # do not mistakenly spawn an empty process pool.
-        raise ValueError("workers must be non-negative")
+    if workers is not None and workers <= 0:
+        # ``0`` and negative counts are nonsensical. Reject them early so
+        # callers do not mistakenly spawn an empty process pool or expect
+        # automatic CPU detection.
+        raise ValueError("workers must be positive")
     if workers is None:
         workers = os.cpu_count() or 1
     if workers <= 1:

--- a/tests/test_batch_generation.py
+++ b/tests/test_batch_generation.py
@@ -94,3 +94,16 @@ def test_generate_batch_negative_workers(monkeypatch):
 
     with pytest.raises(ValueError):
         batch.generate_batch([], workers=-1)
+
+
+def test_generate_batch_zero_workers(monkeypatch):
+    """``0`` workers should raise ``ValueError`` for clarity."""
+
+    batch = importlib.import_module("melody_generator.batch_generation")
+
+    # ``generate_melody`` is a lightweight stub so the test focuses solely on
+    # argument validation inside ``generate_batch``.
+    monkeypatch.setattr(batch, "generate_melody", lambda **kw: [])
+
+    with pytest.raises(ValueError):
+        batch.generate_batch([], workers=0)


### PR DESCRIPTION
## Summary
- treat workers=0 as invalid in `generate_batch`
- note the requirement in the docstring
- test that zero workers raises `ValueError`

## Testing
- `ruff check .`
- `pytest -q`