### PR TITLE
Improve playback player handling

### DIFF
--- a/tests/test_cross_platform_open_player.py
+++ b/tests/test_cross_platform_open_player.py
@@ -76,3 +76,80 @@ def test_open_player_platform_commands(monkeypatch, tmp_path, platform, expected
     assert calls, "subprocess.run was not called"
     assert calls[0] == expected_prefix + [str(midi)]
     assert not midi.exists()
+
+
+def test_custom_player_with_spaces(monkeypatch, tmp_path):
+    """Custom ``MELODY_PLAYER`` containing spaces should be parsed correctly."""
+
+    mido_stub = types.ModuleType("mido")
+    mido_stub.Message = object
+    mido_stub.MidiFile = object
+    mido_stub.MidiTrack = object
+    mido_stub.bpm2tempo = lambda bpm: bpm
+    mido_stub.MetaMessage = object
+    monkeypatch.setitem(sys.modules, "mido", mido_stub)
+
+    tk_stub = types.ModuleType("tkinter")
+    tk_stub.filedialog = types.ModuleType("filedialog")
+    tk_stub.messagebox = types.ModuleType("messagebox")
+    tk_stub.ttk = types.ModuleType("ttk")
+    monkeypatch.setitem(sys.modules, "tkinter", tk_stub)
+    monkeypatch.setitem(sys.modules, "tkinter.filedialog", tk_stub.filedialog)
+    monkeypatch.setitem(sys.modules, "tkinter.messagebox", tk_stub.messagebox)
+    monkeypatch.setitem(sys.modules, "tkinter.ttk", tk_stub.ttk)
+
+    playback = importlib.import_module("melody_generator.playback")
+    open_default_player = playback.open_default_player
+
+    midi = tmp_path / "example.mid"
+    midi.write_text("data")
+
+    calls = []
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(playback.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        playback.os,
+        "environ",
+        {"MELODY_PLAYER": "/usr/bin/custom player"},
+    )
+    monkeypatch.setattr(playback.sys, "platform", "linux", raising=False)
+
+    open_default_player(str(midi), delete_after=True)
+
+    assert calls == [["/usr/bin/custom", "player", str(midi)]]
+    assert not midi.exists()
+
+
+def test_open_default_player_missing_file(monkeypatch):
+    """A nonexistent MIDI file should raise ``FileNotFoundError``."""
+
+    mido_stub = types.ModuleType("mido")
+    mido_stub.Message = object
+    mido_stub.MidiFile = object
+    mido_stub.MidiTrack = object
+    mido_stub.bpm2tempo = lambda bpm: bpm
+    mido_stub.MetaMessage = object
+    monkeypatch.setitem(sys.modules, "mido", mido_stub)
+
+    tk_stub = types.ModuleType("tkinter")
+    tk_stub.filedialog = types.ModuleType("filedialog")
+    tk_stub.messagebox = types.ModuleType("messagebox")
+    tk_stub.ttk = types.ModuleType("ttk")
+    monkeypatch.setitem(sys.modules, "tkinter", tk_stub)
+    monkeypatch.setitem(sys.modules, "tkinter.filedialog", tk_stub.filedialog)
+    monkeypatch.setitem(sys.modules, "tkinter.messagebox", tk_stub.messagebox)
+    monkeypatch.setitem(sys.modules, "tkinter.ttk", tk_stub.ttk)
+
+    playback = importlib.import_module("melody_generator.playback")
+    open_default_player = playback.open_default_player
+
+    monkeypatch.setattr(playback.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(playback.os, "environ", {})
+    monkeypatch.setattr(playback.sys, "platform", "linux", raising=False)
+
+    with pytest.raises(FileNotFoundError):
+        open_default_player("nope.mid")


### PR DESCRIPTION
## Summary
- support MELODY_PLAYER with spaces using `shlex.split`
- validate MIDI path before playing and raise `FileNotFoundError`
- add regression tests for custom player paths and missing files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df5bae5c08321baf91d267a3c25ca