### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout source

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Lint the project using [ruff](https://github.com/astral-sh/ruff):
 ruff check .
 ```
 The linter is configured via `ruff.toml`, which enforces a 100 character
-line length and targets Python 3.8. Adjust this file if different rules
+line length and targets Python 3.10. Adjust this file if different rules
 are required.
 
 ## Continuous Integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ description = "Random melody generator with CLI and GUI"
 authors = [{name = "Austin Boone"}]
 readme = {file = "README.md", content-type = "text/markdown"}
 license = "MIT"
-requires-python = ">=3.8"
+# The codebase relies on features such as the ``|`` union operator
+# introduced in Python 3.10, so earlier versions cannot run the project.
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,8 @@
 # Ruff configuration for Melody-Generator
 # Specifies base lint rules and interpreter version for style enforcement.
 # The line length is aligned with typical PEP8 recommendations while
-# targeting Python 3.8 compatibility for the codebase.
+# targeting Python 3.10 compatibility for the codebase after dropping
+# legacy 3.8 support.
 
 line-length = 100
-target-version = "py38"
+target-version = "py310"

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -4,7 +4,7 @@
 #
 # This helper installs APT packages and Python dependencies required to
 # run Melody-Generator. It checks for an existing Python 3 installation
-# and only installs a new version when the current one is older than 3.8.
+# and only installs a new version when the current one is older than 3.10.
 # A Python virtual environment is created under ./venv.
 #
 # Usage:
@@ -41,15 +41,15 @@ verify_linux() {
     fi
 }
 
-# check_python ensures Python >=3.8 is installed. If python3 is missing or
+# check_python ensures Python >=3.10 is installed. If python3 is missing or
 # too old the function installs a newer version using apt-get.
 check_python() {
     if command -v python3 >/dev/null 2>&1; then
         local version
         version=$(python3 --version 2>&1 | awk '{print $2}')
         local major minor
-        IFS=. read -r major minor _ <<<"$version"
-        if (( major > 3 || (major == 3 && minor >= 8) )); then
+    IFS=. read -r major minor _ <<<"$version"
+    if (( major > 3 || (major == 3 && minor >= 10) )); then
             echo "Found Python $version"
             return
         fi

--- a/scripts/setup_mac.sh
+++ b/scripts/setup_mac.sh
@@ -39,15 +39,15 @@ verify_mac() {
     fi
 }
 
-# check_python ensures Python >=3.8 is installed. If python3 is missing or
+# check_python ensures Python >=3.10 is installed. If python3 is missing or
 # too old the function installs a newer version using Homebrew.
 check_python() {
     if command -v python3 >/dev/null 2>&1; then
         local version
         version=$(python3 -V 2>&1 | awk '{print $2}')
         local major minor
-        IFS=. read -r major minor _ <<<"$version"
-        if (( major > 3 || (major == 3 && minor >= 8) )); then
+    IFS=. read -r major minor _ <<<"$version"
+    if (( major > 3 || (major == 3 && minor >= 10) )); then
             echo "Found Python $version"
             return
         fi

--- a/scripts/setup_windows.ps1
+++ b/scripts/setup_windows.ps1
@@ -25,8 +25,8 @@ function Run-Command($cmd) {
 function Ensure-Python {
     if (Get-Command python -ErrorAction SilentlyContinue) {
         $version = (python --version) -replace 'Python ', ''
-        $parts = $version.Split('.')
-        if ([int]$parts[0] -gt 3 -or ([int]$parts[0] -eq 3 -and [int]$parts[1] -ge 8)) {
+    $parts = $version.Split('.')
+    if ([int]$parts[0] -gt 3 -or ([int]$parts[0] -eq 3 -and [int]$parts[1] -ge 10)) {
             Write-Host "Found Python $version"
             return
         }

--- a/tests/test_setup_linux.py
+++ b/tests/test_setup_linux.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 
 def test_skip_python_install(tmp_path):
-    """Setup script should not install python when version >= 3.8."""
+    """Setup script should not install python when version >= 3.10."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log_file = tmp_path / "log.txt"
@@ -27,7 +27,7 @@ def test_skip_python_install(tmp_path):
     py_path = bin_dir / "python3"
     py_path.write_text(
         "#!/bin/bash\n"
-        "if [ \"$1\" = --version ]; then echo 'Python 3.9.1'; exit 0; fi\n"
+        "if [ \"$1\" = --version ]; then echo 'Python 3.10.1'; exit 0; fi\n"
         "if [ \"$1\" = -m ] && [ \"$2\" = venv ]; then mkdir -p $3/bin; exit 0; fi\n"
     )
     py_path.chmod(0o755)

--- a/tests/test_setup_mac.py
+++ b/tests/test_setup_mac.py
@@ -29,7 +29,7 @@ def test_skip_python_install(tmp_path):
     py_path = bin_dir / "python3"
     py_path.write_text(
         "#!/bin/bash\n"
-        "if [ \"$1\" = -V ]; then echo 'Python 3.9.1'; exit 0; fi\n"
+        "if [ \"$1\" = -V ]; then echo 'Python 3.10.1'; exit 0; fi\n"
         "if [ \"$1\" = -m ] && [ \"$2\" = venv ]; then mkdir -p $3/bin; exit 0; fi\n"
     )
     py_path.chmod(0o755)
@@ -55,7 +55,7 @@ def test_skip_python_install(tmp_path):
         check=True,
     )
 
-    # The script should not attempt to install python because version >=3.8
+    # The script should not attempt to install python because version >=3.10
     assert "brew install python" not in result.stdout
     # But it should attempt to install fluid-synth since brew list fails
     assert "brew install fluid-synth" in result.stdout

--- a/tests/test_setup_windows.py
+++ b/tests/test_setup_windows.py
@@ -16,7 +16,7 @@ import pytest
 
 
 def test_skip_python_install(tmp_path):
-    """Setup script should not install python when version >= 3.8."""
+    """Setup script should not install python when version >= 3.10."""
     if shutil.which("pwsh") is None:
         pytest.skip("pwsh not installed")
     bin_dir = tmp_path / "bin"
@@ -34,7 +34,7 @@ def test_skip_python_install(tmp_path):
     py_path = bin_dir / "python"
     py_path.write_text(
         "#!/bin/bash\n"
-        "if [ \"$1\" = --version ]; then echo 'Python 3.9.1'; exit 0; fi\n"
+        "if [ \"$1\" = --version ]; then echo 'Python 3.10.1'; exit 0; fi\n"
         "if [ \"$1\" = -m ] && [ \"$2\" = venv ]; then mkdir -p $3/bin; exit 0; fi\n"
     )
     py_path.chmod(0o755)


### PR DESCRIPTION
## Summary
- drop Python 3.8 compatibility and require 3.10+
- test on Python 3.10–3.12 in CI
- update version checks in setup scripts and tests
- bump `requires-python` and ruff target version
- refresh documentation about the new Python requirement

## Testing
- `ruff check .`
- `pytest -q`