### PR TITLE
Fix typing hints for pre-3.10 compatibility

### DIFF
--- a/melody_generator/batch_generation.py
+++ b/melody_generator/batch_generation.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import os
 from concurrent.futures import ProcessPoolExecutor
-from typing import Iterable, List, Dict, Any
+from typing import Iterable, List, Dict, Any, Optional
 
 from . import generate_melody
 
@@ -31,7 +31,7 @@ def _generate_single(kwargs: Dict[str, Any]) -> List[str]:
 
 
 def generate_batch(
-    configs: Iterable[Dict[str, Any]], *, workers: int | None = None
+    configs: Iterable[Dict[str, Any]], *, workers: Optional[int] = None
 ) -> List[List[str]]:
     """Generate multiple melodies in parallel.
 

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
-from typing import Callable, List, Tuple, Dict, Optional
+from typing import Callable, List, Tuple, Dict, Optional, Union
 import os
 import threading
 from tempfile import NamedTemporaryFile
@@ -221,7 +221,7 @@ class MelodyGeneratorGUI:
         widget.bind("<Enter>", show)
         widget.bind("<Leave>", hide)
 
-    def _update_bpm_label(self, value: str | int) -> None:
+    def _update_bpm_label(self, value: Union[str, int]) -> None:
         """Display the current BPM next to the slider.
 
         @param value: Slider value to display.
@@ -229,7 +229,7 @@ class MelodyGeneratorGUI:
         """
         self.bpm_label.config(text=str(int(float(value))))
 
-    def _update_notes_label(self, value: str | int) -> None:
+    def _update_notes_label(self, value: Union[str, int]) -> None:
         """Display the current number of notes next to the slider.
 
         @param value: Slider value to display.
@@ -237,7 +237,7 @@ class MelodyGeneratorGUI:
         """
         self.notes_label.config(text=str(int(float(value))))
 
-    def _update_octave_label(self, value: str | int) -> None:
+    def _update_octave_label(self, value: Union[str, int]) -> None:
         """Display the base octave next to its slider.
 
         @param value: Slider value to display.

--- a/melody_generator/performance.py
+++ b/melody_generator/performance.py
@@ -25,6 +25,7 @@ import cProfile
 import io
 import pstats
 from contextlib import contextmanager
+from typing import Optional
 
 try:
     import numpy as np  # type: ignore
@@ -112,7 +113,7 @@ def compute_base_weights(intervals, chord_mask, prev_interval):
 
 
 @contextmanager
-def profile(output: io.TextIOBase | None = None):
+def profile(output: Optional[io.TextIOBase] = None):
     """Context manager that records cProfile statistics for a block."""
 
     pr = cProfile.Profile()

--- a/melody_generator/rhythm_engine.py
+++ b/melody_generator/rhythm_engine.py
@@ -22,7 +22,7 @@ try:
     import numpy as np  # type: ignore
 except Exception:  # pragma: no cover - optional
     np = None
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 BASIC_RHYTHMS = [
@@ -37,9 +37,9 @@ class RhythmGenerator:
 
     def __init__(
         self,
-        transitions: Dict[float, Dict[float, float]] | None = None,
+        transitions: Optional[Dict[float, Dict[float, float]]] = None,
         *,
-        start: float | None = None,
+        start: Optional[float] = None,
     ) -> None:
         """Create a new generator with optional custom transitions.
 

--- a/melody_generator/voice_leading.py
+++ b/melody_generator/voice_leading.py
@@ -23,6 +23,7 @@ Design Notes
 from __future__ import annotations
 
 from . import note_to_midi
+from typing import List, Tuple, Optional, Union
 
 try:
     import numpy as np  # type: ignore
@@ -57,8 +58,8 @@ def counterpoint_penalty(
     prev_note: str,
     candidate: str,
     *,
-    prev_dir: int | None = None,
-    prev_interval: int | None = None,
+    prev_dir: Optional[int] = None,
+    prev_interval: Optional[int] = None,
 ) -> float:
     """Return a bias encouraging contrary motion and avoiding parallels.
 
@@ -101,11 +102,11 @@ def counterpoint_penalty(
 
 def counterpoint_penalties(
     prev_note: str,
-    candidates: list[str] | tuple[str, ...],
+    candidates: Union[List[str], Tuple[str, ...]],
     *,
-    prev_dir: int | None = None,
-    prev_interval: int | None = None,
-) -> "np.ndarray | list[float]":
+    prev_dir: Optional[int] = None,
+    prev_interval: Optional[int] = None,
+) -> "Union[np.ndarray, List[float]]":
     """Return penalties for multiple ``candidates`` at once.
 
     The vectorized implementation uses :mod:`numpy` to compute motion
@@ -127,7 +128,7 @@ def counterpoint_penalties(
 
     Returns
     -------
-    numpy.ndarray | list[float]
+    Union[numpy.ndarray, List[float]]
         Per-candidate penalty adjustments.
     """
 
@@ -164,9 +165,9 @@ def counterpoint_penalties(
 def parallel_fifths_mask(
     prev_a: str,
     prev_b: str,
-    candidates: list[str] | tuple[str, ...],
+    candidates: Union[List[str], Tuple[str, ...]],
     next_b: str,
-) -> "np.ndarray | list[bool]":
+) -> "Union[np.ndarray, List[bool]]":
     """Return a boolean mask for parallel fifth/octave motion.
 
     Each element corresponds to ``candidates`` and indicates whether that

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 
 from importlib import import_module
 from tempfile import NamedTemporaryFile
-from typing import List
+from typing import List, Optional
 
 from melody_generator import playback
 from melody_generator.playback import MidiPlaybackError
@@ -140,7 +140,7 @@ def _generate_preview(
     include_chords: bool,
     chords_same: bool,
     enable_ml: bool,
-    style: str | None,
+    style: Optional[str],
     chords: List[str],
     humanize: bool,
 ) -> tuple[str, str]:


### PR DESCRIPTION
## Summary
- switch all `|` union syntax to `Optional` or `Union`
- adjust imports for `Optional`/`Union`

## Testing
- `ruff check .`
- `pytest -q`