### PR TITLE
Add time signature validation utility

### DIFF
--- a/melody_generator/cli.py
+++ b/melody_generator/cli.py
@@ -41,6 +41,7 @@ from . import (
     MIN_OCTAVE,
     SCALE,
 )
+from .utils import validate_time_signature
 
 
 __all__ = ["run_cli", "main"]
@@ -164,12 +165,7 @@ def run_cli() -> None:
                 sys.exit(1)
 
     try:
-        parts = args.timesig.split("/")
-        if len(parts) != 2:
-            raise ValueError
-        numerator, denominator = map(int, parts)
-        if numerator <= 0 or denominator not in {1, 2, 4, 8, 16}:
-            raise ValueError
+        numerator, denominator = validate_time_signature(args.timesig)
     except ValueError:
         logging.error(
             "Time signature must be in the form 'numerator/denominator' with numerator > 0 and denominator one of 1, 2, 4, 8 or 16."

--- a/melody_generator/utils.py
+++ b/melody_generator/utils.py
@@ -1,0 +1,61 @@
+"""Utility helpers shared across Melody Generator components.
+
+This module collects lightweight functions that do not fit in more
+specific modules.  Each helper is carefully documented so both the CLI
+and GUI can reuse the same validation logic without duplicating code.
+
+Usage Example
+-------------
+>>> from melody_generator.utils import validate_time_signature
+>>> validate_time_signature("3/4")
+(3, 4)
+"""
+
+from __future__ import annotations
+
+__all__ = ["validate_time_signature"]
+
+
+def validate_time_signature(ts: str) -> tuple[int, int]:
+    """Parse and validate a time signature string.
+
+    Parameters
+    ----------
+    ts:
+        Time signature in ``"NUM/DEN"`` form. Whitespace around the
+        separator is ignored.
+
+    Returns
+    -------
+    tuple[int, int]
+        ``(numerator, denominator)`` when ``ts`` is valid.
+
+    Raises
+    ------
+    ValueError
+        If ``ts`` is malformed or uses an unsupported denominator.
+    """
+
+    # Accept input such as "4/4" or " 3 / 8 " by trimming whitespace
+    parts = ts.strip().split("/")
+    if len(parts) != 2:
+        raise ValueError(
+            "Time signature must be in the form 'numerator/denominator'."
+        )
+
+    try:
+        numerator = int(parts[0])
+        denominator = int(parts[1])
+    except ValueError as exc:  # non-integer values
+        raise ValueError(
+            "Time signature must contain integer numerator and denominator."
+        ) from exc
+
+    # Restrict denominator to common simple meter values
+    valid_denominators = {1, 2, 4, 8, 16}
+    if numerator <= 0 or denominator not in valid_denominators:
+        raise ValueError(
+            "Time signature numerator must be > 0 and denominator one of 1, 2, 4, 8 or 16."
+        )
+
+    return numerator, denominator

--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -67,6 +67,7 @@ from typing import List, Optional
 
 from melody_generator import playback
 from melody_generator.playback import MidiPlaybackError
+from melody_generator.utils import validate_time_signature
 
 try:
     from celery import Celery
@@ -345,12 +346,7 @@ def index():
                         return render_template('index.html', scale=sorted(SCALE.keys()), instruments=INSTRUMENTS.keys(), styles=STYLE_VECTORS.keys())
 
         try:
-            parts = timesig.split('/')
-            if len(parts) != 2:
-                raise ValueError
-            numerator, denominator = map(int, parts)
-            if numerator <= 0 or denominator not in {1, 2, 4, 8, 16}:
-                raise ValueError
+            numerator, denominator = validate_time_signature(timesig)
         except ValueError:
             flash(
                 "Time signature must be in the form 'numerator/denominator' with numerator > 0 and denominator one of 1, 2, 4, 8 or 16."

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -66,6 +66,9 @@ create_midi_file = mg.create_midi_file
 MIN_OCTAVE = mg.MIN_OCTAVE
 MAX_OCTAVE = mg.MAX_OCTAVE
 PolyphonicGenerator = importlib.import_module("melody_generator.polyphony").PolyphonicGenerator
+validate_time_signature = importlib.import_module(
+    "melody_generator.utils"
+).validate_time_signature
 
 
 def test_create_midi_file_empty_chord_progression(tmp_path) -> None:
@@ -90,3 +93,21 @@ def test_generate_base_octaves_out_of_range() -> None:
         gen.generate("C", 4, ["C"], base_octaves={"soprano": MIN_OCTAVE - 1})
     with pytest.raises(ValueError):
         gen.generate("C", 4, ["C"], base_octaves={"alto": MAX_OCTAVE + 1})
+
+
+def test_validate_time_signature_success() -> None:
+    """Typical time signatures should parse into integer tuples."""
+
+    assert validate_time_signature("4/4") == (4, 4)
+    assert validate_time_signature("7/8") == (7, 8)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["4", "3/5", "0/4", "-2/4", "A/B"],
+)
+def test_validate_time_signature_errors(value: str) -> None:
+    """Malformed or unsupported signatures should raise ``ValueError``."""
+
+    with pytest.raises(ValueError):
+        validate_time_signature(value)


### PR DESCRIPTION
## Summary
- add `validate_time_signature` helper in `utils.py`
- switch CLI and web GUI to use the helper
- test normal and failure cases in `test_validation_errors`

## Testing
- `pytest -q`