### PR TITLE
Update harmony line validation message

### DIFF
--- a/melody_generator/web_gui.py
+++ b/melody_generator/web_gui.py
@@ -58,6 +58,8 @@ infrastructure.
 #     generation fails so no stale files accumulate under ``/tmp``.
 #   * ``load_sequence_model`` caches models by path and vocabulary size to
 #     avoid repeatedly loading the same weights from disk during preview.
+#   * Flash message for invalid harmony line counts now clarifies that zero is
+#     permitted.
 
 from __future__ import annotations
 
@@ -300,7 +302,9 @@ def index():
             )
 
         if harmony_lines < 0:
-            flash("Harmony lines must be greater than 0.")
+            # Inform the user that negative values are invalid while zero is
+            # acceptable so monophonic melodies remain supported.
+            flash("Harmony lines must be non-negative.")
             return render_template(
                 'index.html',
                 scale=sorted(SCALE.keys()),

--- a/tests/test_web_gui.py
+++ b/tests/test_web_gui.py
@@ -320,7 +320,8 @@ def test_negative_harmony_lines_flash():
             "harmony_lines": "-1",
         },
     )
-    assert b"Harmony lines must be greater than 0" in resp.data
+    # The form should explicitly allow zero harmony lines but reject negatives.
+    assert b"Harmony lines must be non-negative" in resp.data
 
 
 def test_include_chords_flag():


### PR DESCRIPTION
## Summary
- clarify comment that harmony line message allows zero
- flash "Harmony lines must be non-negative" for negative counts
- adjust unit test to expect new message

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687179de6ec88321b89a439716efc794