### PR TITLE
Fix Tkinter init order

### DIFF
--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -25,6 +25,9 @@ counterpoint generation is delegated to :mod:`melody_generator`.
 # * ``_generate_button_click`` now validates ``base_octave`` against
 #   ``MIN_OCTAVE`` and ``MAX_OCTAVE`` so the register remains within the
 #   MIDI specification.
+# * ``__init__`` creates the Tk root before any ``BooleanVar`` or
+#   ``StringVar`` objects to comply with Python 3.12's stricter Tkinter
+#   initialization requirements.
 # ---------------------------------------------------------------
 from __future__ import annotations
 
@@ -118,15 +121,21 @@ class MelodyGeneratorGUI:
         self.counterpoint_fn = counterpoint_fn
 
         self.rhythm_pattern: Optional[List[float]] = None
-        self.ml_var = tk.BooleanVar(value=False)
-        self.humanize_var = tk.BooleanVar(value=True)
-        self.style_var = tk.StringVar(value="")
-        # Seed for deterministic generation. Empty string disables seeding.
-        self.seed_var = tk.StringVar(value="")
-        self.styles = sorted(STYLE_VECTORS.keys())
 
+        # The Tk root must exist before creating any Tkinter variables.
+        # Python 3.12 enforces this requirement whereas older versions
+        # implicitly created a root.  By instantiating the window first and
+        # explicitly passing it as ``master`` all ``BooleanVar`` and
+        # ``StringVar`` objects are guaranteed a valid context.
         self.root = tk.Tk()
         self.root.title("Melody Generator")
+
+        self.ml_var = tk.BooleanVar(master=self.root, value=False)
+        self.humanize_var = tk.BooleanVar(master=self.root, value=True)
+        self.style_var = tk.StringVar(master=self.root, value="")
+        # Seed for deterministic generation. Empty string disables seeding.
+        self.seed_var = tk.StringVar(master=self.root, value="")
+        self.styles = sorted(STYLE_VECTORS.keys())
 
         self._setup_theme()
         self._build_widgets()

--- a/tests/test_gui_initialization.py
+++ b/tests/test_gui_initialization.py
@@ -1,0 +1,93 @@
+"""Regression tests for the desktop GUI initialization order.
+
+The GUI used to create ``BooleanVar`` and ``StringVar`` instances before the
+Tk root existed, which raises ``RuntimeError`` on Python 3.12. These tests
+patch ``tkinter`` so the initialization can run headless and verify that
+the variables share the newly created root.
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+import tkinter as tk
+
+# Ensure the repository root is on ``sys.path`` so the package can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_gui_init_root_before_vars(monkeypatch):
+    """The root window must be created prior to Tk variables."""
+    # Stub ``mido`` so the module can be imported without the real dependency.
+    stub_mido = types.ModuleType("mido")
+    stub_mido.Message = lambda *a, **k: None
+
+    class DummyMidiFile:
+        def __init__(self, *a, **k):
+            self.tracks = []
+
+        def save(self, _path):
+            pass
+
+    stub_mido.MidiFile = DummyMidiFile
+    stub_mido.MidiTrack = lambda *a, **k: []
+    stub_mido.MetaMessage = lambda *a, **k: None
+    stub_mido.bpm2tempo = lambda bpm: bpm
+    monkeypatch.setitem(sys.modules, "mido", stub_mido)
+
+    gui_mod = importlib.import_module("melody_generator.gui")
+
+    class DummyTk:
+        """Minimal stand-in for ``tkinter.Tk`` that works without a display."""
+
+        def __init__(self, *args, **kwargs):
+            # ``_tkinter.create`` with ``wantTk=False`` provides a Tcl interpreter
+            # without requiring any windowing system.
+            import _tkinter
+
+            self.tk = _tkinter.create(
+                None, "py", "Tk", False, False, False, False, None
+            )
+            self.master = None
+            self._w = "."
+            tk._default_root = self
+
+        def _root(self):
+            return self
+
+        def __call__(self, *args):
+            return self.tk.call(*args)
+
+        def title(self, *args, **kwargs):
+            pass
+
+        def option_add(self, *args, **kwargs):
+            pass
+
+        def configure(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(gui_mod.tk, "Tk", DummyTk)
+
+    # Skip widget creation to keep the test lightweight.
+    monkeypatch.setattr(gui_mod.MelodyGeneratorGUI, "_setup_theme", lambda self: None)
+    monkeypatch.setattr(gui_mod.MelodyGeneratorGUI, "_build_widgets", lambda self: None)
+    monkeypatch.setattr(gui_mod.MelodyGeneratorGUI, "_apply_theme", lambda self: None)
+    monkeypatch.setattr(
+        gui_mod.MelodyGeneratorGUI, "_check_preview_available", lambda self: None
+    )
+
+    gui = gui_mod.MelodyGeneratorGUI(
+        generate_melody=lambda *a, **k: [],
+        create_midi_file=lambda *a, **k: None,
+        scale={"C": ["C"]},
+        chords={"C": ["C"]},
+    )
+
+    # ``Variable`` instances store the root object in ``_root``. The ``str``
+    # representation of this object is ``"."`` but identity should match the
+    # ``DummyTk`` instance created above.
+    assert gui.ml_var._root is gui.root
+    assert gui.humanize_var._root is gui.root
+    assert gui.style_var._root is gui.root
+    assert gui.seed_var._root is gui.root


### PR DESCRIPTION
## Summary
- create Tk root before tk variables
- regression test for GUI initialization order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758b9a336083218825b2ebb653c960