### PR TITLE
Add chord progression validation in refine_with_fmd

### DIFF
--- a/melody_generator/feedback.py
+++ b/melody_generator/feedback.py
@@ -12,6 +12,13 @@ Example
 >>> improved = refine_with_fmd(melody, "C", ["C"], 4)
 """
 
+# Changelog
+# ---------
+# - Added validation for empty chord progressions in ``refine_with_fmd``.  The
+#   previous implementation assumed at least one chord was supplied and would
+#   fail with a modulo-by-zero error when the progression was empty.  Raising a
+#   ``ValueError`` provides immediate, user-friendly feedback.
+
 from __future__ import annotations
 
 import math
@@ -96,6 +103,12 @@ def refine_with_fmd(
         # modify while keeping the first and last notes fixed, so simply
         # return the melody unchanged.
         return melody
+
+    if not chord_prog:
+        # The candidate note pool relies on a chord progression.  An empty list
+        # would lead to modulo-by-zero errors when selecting chords, so we fail
+        # fast with a clear message.
+        raise ValueError("chord_prog must contain at least one chord")
 
     size = max(1, int(len(melody) * 0.05))
     best_score = compute_fmd(melody)

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -69,3 +69,12 @@ def test_refine_with_fmd_short_sequences_return_input():
     assert fb.refine_with_fmd(one.copy(), "C", ["C"], 4) == one
     assert fb.refine_with_fmd(two.copy(), "C", ["C"], 4) == two
 
+
+def test_refine_with_fmd_raises_on_empty_chord_prog():
+    """Empty chord progressions cannot guide note selection and should error."""
+
+    fb = importlib.import_module("melody_generator.feedback")
+
+    with pytest.raises(ValueError):
+        fb.refine_with_fmd(["C4", "E4", "G4"], "C", [], 4)
+


### PR DESCRIPTION
## Summary
- ensure `refine_with_fmd` rejects empty chord progressions to avoid runtime errors
- cover empty progression error handling with new unit test

## Testing
- `pytest tests/test_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689428d6c1a883219c72408cfd3b8a8b