### PR TITLE
feat: clarify unknown note errors

### DIFF
--- a/melody_generator/note_utils.py
+++ b/melody_generator/note_utils.py
@@ -11,6 +11,12 @@ Example
 60
 """
 
+# Modification Summary
+# ---------------------
+# * Improved error reporting in ``note_to_midi`` by raising a descriptive
+#   ``ValueError`` when an unknown note name is encountered. Previously a bare
+#   ``KeyError`` was re-raised, which obscured the cause for callers.
+
 from __future__ import annotations
 
 import logging
@@ -66,8 +72,10 @@ def note_to_midi(note: str) -> int:
     try:
         note_idx = NOTE_TO_SEMITONE[note_name]
     except KeyError:
-        logging.error("Note %s not recognized.", note_name)
-        raise
+        logging.error("Unknown note name: %s", note_name)
+        # Convert the internal KeyError into a user-facing ValueError so that
+        # callers receive a clear message about the invalid note name.
+        raise ValueError(f"Unknown note name: {note_name}")
 
     midi_val = note_idx + (octave * 12)
     return max(0, min(127, midi_val))

--- a/tests/test_note_to_midi.py
+++ b/tests/test_note_to_midi.py
@@ -1,12 +1,14 @@
 """Unit tests for the ``note_to_midi`` helper.
 
 The helper converts note names such as ``C#4`` or ``Db4`` into MIDI numbers.
-These tests confirm that enharmonic spellings map to the same value."""
+These tests confirm that enharmonic spellings map to the same value and that
+invalid notes raise clear errors."""
 
 import sys
 from pathlib import Path
 import types
 import importlib
+import pytest
 
 # Provide a minimal dummy 'mido' module so the script can be imported without the dependency
 mido_stub = types.ModuleType('mido')
@@ -33,6 +35,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 melody_generator = importlib.import_module("melody_generator")
 note_to_midi = melody_generator.note_to_midi
+note_utils_mod = importlib.import_module("melody_generator.note_utils")
 
 
 def test_sharp_conversion():
@@ -58,3 +61,18 @@ def test_multi_digit_octaves():
 def test_negative_octaves_clamped():
     """Notes below MIDI 0 clamp to 0."""
     assert note_to_midi('C-2') == 0
+
+
+def test_unknown_note_raises_value_error(monkeypatch):
+    """Unknown note names result in a descriptive ``ValueError``.
+
+    The mapping dictionary normally includes all valid pitch classes. We
+    temporarily remove one entry to simulate an unexpected note and verify the
+    helper surfaces a clear error message.
+    """
+
+    monkeypatch.delitem(note_utils_mod.NOTE_TO_SEMITONE, "C", raising=False)
+    note_utils_mod.note_to_midi.cache_clear()
+    with pytest.raises(ValueError, match="Unknown note name: C"):
+        note_utils_mod.note_to_midi("C4")
+


### PR DESCRIPTION
## Summary
- raise ValueError with descriptive message when note name not recognized
- test that note_to_midi surfaces clear error for unknown notes

## Testing
- `ruff check melody_generator/note_utils.py tests/test_note_to_midi.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ebc81e6548321b788cf6d608a57f4