### PR TITLE
Reject non-positive BPM values

### DIFF
--- a/melody_generator/midi_io.py
+++ b/melody_generator/midi_io.py
@@ -6,6 +6,8 @@ Modification summary
   callers can pass a path in a new folder without preparing it.
 * ``create_midi_file`` accounts for extra inserted beats when extending the
   melody so chord tracks remain aligned with the final note.
+* ``create_midi_file`` validates ``bpm`` is positive so invalid tempos are
+  caught early.
 
 This module contains the low-level helpers used to render melodies as MIDI and
 open the resulting files with the user's default player. It is separated from
@@ -57,6 +59,11 @@ def create_midi_file(
     directory of ``output_file`` is created automatically so callers may supply
     paths in a new folder without preparing it beforehand.
     """
+    # ``bpm`` determines the tempo of the piece; values less than or equal to
+    # zero would yield invalid timing information. Validate early so callers
+    # receive a clear error instead of generating a nonsensical MIDI file.
+    if bpm <= 0:
+        raise ValueError("bpm must be a positive integer")
 
     if chord_progression is not None and not chord_progression:
         raise ValueError("chord_progression must contain at least one chord")

--- a/tests/test_validation_errors.py
+++ b/tests/test_validation_errors.py
@@ -83,6 +83,18 @@ def test_create_midi_file_empty_chord_progression(tmp_path) -> None:
         create_midi_file(melody, 120, (4, 4), str(out), chord_progression=[])
 
 
+@pytest.mark.parametrize("bpm", [0, -120])
+def test_create_midi_file_invalid_bpm(bpm: int, tmp_path) -> None:
+    """``create_midi_file`` should reject non-positive ``bpm`` values."""
+
+    melody = ["C4"]
+    out = tmp_path / "out.mid"
+    # Tempo defines note spacing; zero or negative BPM is nonsensical and must
+    # raise ``ValueError`` so callers correct their input before file creation.
+    with pytest.raises(ValueError):
+        create_midi_file(melody, bpm, (4, 4), str(out))
+
+
 def test_generate_base_octaves_out_of_range() -> None:
     """``generate`` should validate octave overrides for each voice."""
 


### PR DESCRIPTION
## Summary
- ensure create_midi_file fails fast when bpm <= 0
- test non-positive BPM handling

## Testing
- `ruff check melody_generator/midi_io.py tests/test_validation_errors.py`
- `pytest tests/test_validation_errors.py::test_create_midi_file_invalid_bpm -q`