### PR TITLE
Add genre-aware model training and selection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ additional background on how the system works or how to configure audio playback
   model, style embeddings and tension weighting used in the generator.
 - [Musician's Overview](README_MUSICAL_OVERVIEW.md) – Introduction to the
   project for classical performers and composers.
+- [Training Larger Models](README_TRAINING.md) – Guide for fitting
+  Transformer/ VAE models on genre-specific MIDI datasets.
 
 Each document is self-contained so you can jump directly to the topic that
 interests you.

--- a/docs/README_TRAINING.md
+++ b/docs/README_TRAINING.md
@@ -1,0 +1,57 @@
+# Training Larger Models
+
+This guide describes how to train more expressive machine learning models on
+multi-genre MIDI datasets. Each genre receives its own checkpoint so the
+runtime system can bias note selection toward stylistic patterns.
+
+## Dataset Layout
+
+The training script expects a directory structure similar to::
+
+    data_root/
+        jazz/
+            file1.mid
+            file2.mid
+        rock/
+            song1.mid
+            song2.mid
+
+Each subfolder represents a genre and contains MIDI files used for that
+style. Additional genres can be added as new subdirectories.
+
+## Running Training
+
+Use the :mod:`scripts.train_multi_genre` helper to fit either a Transformer
+or variational autoencoder model for each genre:
+
+```bash
+python scripts/train_multi_genre.py \
+    --data-root /path/to/data_root \
+    --genres jazz rock classical \
+    --model transformer \
+    --epochs 20 \
+    --checkpoint-dir models
+```
+
+Checkpoints are written as ``{genre}.pt`` into ``models`` by default. These
+files can be selected at runtime via the CLI using ``--genre`` and
+``--model-dir``.
+
+## Runtime Selection
+
+When invoking the command-line generator, specify ``--enable-ml`` and
+optionally ``--genre`` to bias toward a particular style:
+
+```bash
+python -m melody_generator.cli --enable-ml --genre jazz --model-dir models ...
+```
+
+If the requested genre checkpoint is missing or corrupt, the application
+falls back to an untrained model so generation still succeeds.
+
+## Extending
+
+The provided training script focuses on clarity. For real projects consider
+incorporating data augmentation, larger model architectures and longer
+training schedules. The script serves as a starting point that can be
+expanded to suit specific research goals.

--- a/melody_generator/__init__.py
+++ b/melody_generator/__init__.py
@@ -152,6 +152,7 @@ from .sequence_model import (
     MelodyLSTM,  # noqa: F401
     predict_next,  # noqa: F401
     load_sequence_model,  # noqa: F401
+    load_genre_sequence_model,  # noqa: F401
 )  # noqa: F401
 # Re-export the full module so ``melody_generator.style_embeddings`` exists for
 # callers that rely on the submodule attribute.  Tests importing the web GUI

--- a/scripts/train_multi_genre.py
+++ b/scripts/train_multi_genre.py
@@ -1,0 +1,250 @@
+"""Train genre-specific sequence models on multi-genre MIDI corpora.
+
+This script provides a minimal training harness capable of fitting either a
+Transformer encoder/decoder or a simple variational autoencoder (VAE) on a
+set of MIDI files grouped by musical genre. Each subdirectory under a user
+supplied ``data_root`` path is treated as a genre and is expected to contain
+``.mid`` files. A separate model is trained for each genre and saved as
+``{genre}.pt`` in ``checkpoint_dir``. These checkpoints can later be loaded at
+runtime via :func:`melody_generator.load_genre_sequence_model`.
+
+Example
+-------
+Assuming ``~/midi_corpus`` contains ``jazz/`` and ``rock/`` folders with MIDI
+files, the following will train lightweight Transformer models and store the
+weights beneath ``models/``::
+
+    python scripts/train_multi_genre.py \
+        --data-root ~/midi_corpus \
+        --genres jazz rock \
+        --model transformer \
+        --epochs 10 \
+        --checkpoint-dir models
+
+Design Notes
+------------
+The implementation intentionally favours clarity over raw performance so the
+core ideas remain accessible. Real-world projects should incorporate richer
+preprocessing, larger models and thorough evaluation. Nevertheless this script
+serves as a concrete starting point for experimenting with genre-aware models.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+try:
+    import mido
+except Exception as exc:  # pragma: no cover - MIDI parsing optional
+    raise RuntimeError("mido is required for training") from exc
+
+# ---------------------------------------------------------------------------
+# Utility data structures
+# ---------------------------------------------------------------------------
+
+
+class MidiDataset(Dataset):
+    """Convert MIDI note-on messages to pitch indices for model training.
+
+    Parameters
+    ----------
+    files:
+        Iterable of ``Path`` objects pointing to MIDI files.
+    vocab:
+        Mapping of MIDI pitch to a contiguous index. Only notes present in
+        ``vocab`` are retained; others are skipped to keep the implementation
+        compact. Real projects may wish to handle unknown pitches differently.
+    """
+
+    def __init__(self, files: Iterable[Path], vocab: Dict[int, int]) -> None:
+        self.files = list(files)
+        self.vocab = vocab
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.files)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        midi = mido.MidiFile(self.files[idx])
+        notes: List[int] = []
+        for track in midi.tracks:
+            for msg in track:
+                if msg.type == "note_on" and msg.velocity > 0:
+                    # Only retain pitches present in the vocabulary.
+                    if msg.note in self.vocab:
+                        notes.append(self.vocab[msg.note])
+        if not notes:
+            # Provide a minimal guarantee to avoid zero-length tensors.
+            notes.append(0)
+        return torch.tensor(notes, dtype=torch.long)
+
+
+# ---------------------------------------------------------------------------
+# Model definitions
+# ---------------------------------------------------------------------------
+
+
+class SimpleTransformer(nn.Module):
+    """Tiny Transformer encoder/decoder for sequence modelling.
+
+    The model is intentionally small so examples run quickly. It embeds each
+    pitch, applies a stack of Transformer encoder layers and predicts the next
+    index in the sequence.
+    """
+
+    def __init__(self, vocab_size: int, d_model: int = 128, nhead: int = 4, num_layers: int = 2) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, d_model)
+        encoder_layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead)
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        self.fc = nn.Linear(d_model, vocab_size)
+
+    def forward(self, seq: torch.Tensor) -> torch.Tensor:  # pragma: no cover - thin wrapper
+        # ``seq``: (T) tensor of indices. We add a batch dimension for the encoder.
+        emb = self.embed(seq).unsqueeze(1)
+        encoded = self.encoder(emb)
+        return self.fc(encoded[-1])
+
+
+class SimpleVAE(nn.Module):
+    """Minimal VAE operating on note index sequences.
+
+    The VAE compresses each sequence into a latent vector and reconstructs the
+    next-note distribution. This toy implementation illustrates the concept
+    without aiming for high musical fidelity.
+    """
+
+    def __init__(self, vocab_size: int, latent_dim: int = 32) -> None:
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, latent_dim)
+        self.encoder = nn.GRU(latent_dim, latent_dim, batch_first=True)
+        self.to_mean = nn.Linear(latent_dim, latent_dim)
+        self.to_logvar = nn.Linear(latent_dim, latent_dim)
+        self.decoder = nn.GRU(latent_dim, latent_dim, batch_first=True)
+        self.out = nn.Linear(latent_dim, vocab_size)
+
+    def forward(self, seq: torch.Tensor) -> torch.Tensor:  # pragma: no cover - example
+        emb = self.embed(seq).unsqueeze(0)
+        _, hidden = self.encoder(emb)
+        mean = self.to_mean(hidden[-1])
+        logvar = self.to_logvar(hidden[-1])
+        std = torch.exp(0.5 * logvar)
+        z = mean + torch.randn_like(std) * std
+        dec_out, _ = self.decoder(z.unsqueeze(0))
+        return self.out(dec_out.squeeze(0))
+
+
+# ---------------------------------------------------------------------------
+# Training helpers
+# ---------------------------------------------------------------------------
+
+
+def build_model(model_type: str, vocab_size: int) -> nn.Module:
+    """Return a model instance based on ``model_type``.
+
+    Parameters
+    ----------
+    model_type:
+        Either ``"transformer"`` or ``"vae"``. The comparison is case-insensitive.
+    vocab_size:
+        Number of unique notes in the dataset.
+
+    Raises
+    ------
+    ValueError
+        If ``model_type`` is not recognised.
+    """
+
+    model_type = model_type.lower()
+    if model_type == "transformer":
+        return SimpleTransformer(vocab_size)
+    if model_type == "vae":
+        return SimpleVAE(vocab_size)
+    raise ValueError(f"Unsupported model type: {model_type}")
+
+
+def train_one_epoch(model: nn.Module, loader: DataLoader, criterion: nn.Module, optim: torch.optim.Optimizer) -> float:
+    """Train ``model`` for a single epoch and return the average loss."""
+
+    model.train()
+    total_loss = 0.0
+    for seq in loader:
+        optim.zero_grad()
+        logits = model(seq[0])  # Use first sequence position to predict next
+        loss = criterion(logits, seq[0])
+        loss.backward()
+        optim.step()
+        total_loss += loss.item()
+    return total_loss / len(loader)
+
+
+def train_genre_model(
+    genre: str,
+    data_dir: Path,
+    model_type: str,
+    epochs: int,
+    checkpoint_dir: Path,
+    vocab: Dict[int, int],
+) -> None:
+    """Train a model for ``genre`` and save the resulting checkpoint."""
+
+    files = list(data_dir.glob("*.mid"))
+    if not files:
+        raise ValueError(f"No MIDI files found for genre '{genre}' in {data_dir}")
+
+    dataset = MidiDataset(files, vocab)
+    loader = DataLoader(dataset, batch_size=1, shuffle=True)
+    model = build_model(model_type, len(vocab))
+    criterion = nn.CrossEntropyLoss()
+    optim = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    for epoch in range(epochs):
+        loss = train_one_epoch(model, loader, criterion, optim)
+        logging.info("%s epoch %d loss %.4f", genre, epoch + 1, loss)
+
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), checkpoint_dir / f"{genre}.pt")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    """Return parsed command line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-root", type=Path, required=True, help="Root directory containing genre subfolders with MIDI files")
+    parser.add_argument("--genres", nargs="+", help="List of genres to train (each must match a subdirectory name)")
+    parser.add_argument("--model", choices=["transformer", "vae"], default="transformer", help="Model architecture to train")
+    parser.add_argument("--epochs", type=int, default=5, help="Number of epochs to train each model")
+    parser.add_argument("--checkpoint-dir", type=Path, default=Path("models"), help="Output directory for saved checkpoints")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point used when executing the module as a script."""
+
+    args = parse_args()
+    if args.epochs <= 0:
+        raise ValueError("epochs must be a positive integer")
+    # Build a simple vocabulary spanning the full MIDI range. Real projects may
+    # derive this from the dataset instead.
+    vocab = {midi: idx for idx, midi in enumerate(range(128))}
+
+    for genre in args.genres:
+        data_dir = args.data_root / genre
+        if not data_dir.exists():
+            raise ValueError(f"Genre directory does not exist: {data_dir}")
+        train_genre_model(genre, data_dir, args.model, args.epochs, args.checkpoint_dir, vocab)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    main()

--- a/tests/test_cli_gui_integration.py
+++ b/tests/test_cli_gui_integration.py
@@ -256,8 +256,9 @@ def test_cli_enable_ml_and_style(tmp_path, monkeypatch):
     output = tmp_path / "out.mid"
     called = {}
 
-    def fake_load(path, vocab):
-        called["loaded"] = True
+    def fake_load(genre, directory, vocab):
+        # Record that the loader was invoked with the expected signature.
+        called["loaded"] = (genre, directory, vocab)
         return object()
 
     def gen_mel(*args, **kwargs):
@@ -265,7 +266,7 @@ def test_cli_enable_ml_and_style(tmp_path, monkeypatch):
         called["style"] = kwargs.get("style")
         return ["C4"]
 
-    monkeypatch.setattr(mod, "load_sequence_model", fake_load)
+    monkeypatch.setattr(mod, "load_genre_sequence_model", fake_load)
     monkeypatch.setattr(mod, "generate_melody", gen_mel)
     argv = [
         "prog",

--- a/tests/test_genre_model_loading.py
+++ b/tests/test_genre_model_loading.py
@@ -1,0 +1,49 @@
+"""Tests for genre-specific model selection helpers."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def _reload_module():
+    """Reload ``sequence_model`` fresh for each test."""
+    return importlib.reload(importlib.import_module("melody_generator.sequence_model"))
+
+
+def test_existing_genre_loads_checkpoint(tmp_path, monkeypatch):
+    """A matching checkpoint path should be passed to ``load_sequence_model``."""
+    seq_mod = _reload_module()
+
+    calls = []
+
+    def fake_loader(path, vocab):
+        calls.append(path)
+        return object()
+
+    monkeypatch.setattr(seq_mod, "load_sequence_model", fake_loader)
+    (tmp_path / "jazz.pt").write_bytes(b"dummy")
+
+    result = seq_mod.load_genre_sequence_model("jazz", str(tmp_path), 8)
+    assert result is not None
+    assert calls == [str(tmp_path / "jazz.pt")]
+
+
+def test_missing_genre_falls_back(tmp_path, monkeypatch):
+    """Errors from ``load_sequence_model`` should trigger a fallback to ``None``."""
+    seq_mod = _reload_module()
+
+    calls = []
+
+    def fake_loader(path, vocab):
+        calls.append(path)
+        if path is not None:
+            raise ValueError("missing")
+        return "default"
+
+    monkeypatch.setattr(seq_mod, "load_sequence_model", fake_loader)
+
+    result = seq_mod.load_genre_sequence_model("rock", str(tmp_path), 8)
+    # ``fake_loader`` should first be called with the checkpoint path then ``None``.
+    assert calls == [str(tmp_path / "rock.pt"), None]
+    assert result == "default"


### PR DESCRIPTION
## Summary
- add `load_genre_sequence_model` for genre-specific checkpoint loading with untrained fallback
- expose `--genre` and `--model-dir` CLI options for selecting checkpoints at runtime
- provide `train_multi_genre.py` script and docs for training transformer/VAE models on multi-genre MIDI datasets
- cover genre loading and fallback logic with dedicated tests

## Testing
- `pytest -q`