### PR TITLE
chore: pin numpy for optional ml deps

### DIFF
--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -11,6 +11,9 @@
 #   * Refresh the APT package index unconditionally at the start of the
 #     ``main`` function. This prevents package lookup failures on freshly
 #     provisioned systems where the local cache may be empty.
+#   * Pin ``numpy`` to versions below 2 when optionally installing machine
+#     learning dependencies. The pin avoids conflicts with the project's
+#     core dependency constraints which currently expect the 1.x series.
 #
 # Usage:
 #   ./setup_linux.sh
@@ -19,7 +22,8 @@
 # executing them. This is useful for verifying the commands on systems
 # where sudo privileges might be restricted. Set INSTALL_ML_DEPS=1 to also
 # install optional machine learning libraries used by the sequence model
-# and style embedding features. When enabled the script installs ``numpy``,
+# and style embedding features. When enabled the script installs ``numpy``
+# (pinned to <2 to maintain compatibility with the rest of the project),
 # ``torch`` (CPU build), ``onnxruntime`` and ``numba`` in the virtual
 # environment.
 #----------------------------------------------------------------------
@@ -98,7 +102,7 @@ main() {
         echo "DRY RUN: pip install -r requirements.txt"
         echo "DRY RUN: pip install -e ."
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            echo "DRY RUN: pip install numpy"
+            echo "DRY RUN: pip install \"numpy<2\""  # Pin <2 to prevent core dependency conflicts
             echo "DRY RUN: pip install torch --index-url https://download.pytorch.org/whl/cpu"
             echo "DRY RUN: pip install onnxruntime"
             echo "DRY RUN: pip install numba"
@@ -110,7 +114,7 @@ main() {
         run_cmd pip install -r requirements.txt
         run_cmd pip install -e .
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            run_cmd pip install numpy
+            run_cmd pip install "numpy<2"  # Pin <2 to prevent core dependency conflicts
             run_cmd pip install torch --index-url https://download.pytorch.org/whl/cpu
             run_cmd pip install onnxruntime
             run_cmd pip install numba

--- a/scripts/setup_mac.sh
+++ b/scripts/setup_mac.sh
@@ -6,15 +6,21 @@
 # to run Melody-Generator. It performs version checks so that existing
 # installations are reused when possible.
 #
+# Modification summary:
+#   * Pin ``numpy`` to versions below 2 when optionally installing machine
+#     learning dependencies. The pin avoids conflicts with the project's
+#     core dependency constraints which currently expect the 1.x series.
+#
 # Usage:
 #   ./setup_mac.sh
 #
 # Set the environment variable DRY_RUN=1 to print commands without
 # executing them. The FORCE_MAC=1 variable allows running the script on
 # non-macOS systems (useful for CI testing). Set INSTALL_ML_DEPS=1 to
-# also install optional machine learning libraries (``numpy``, the CPU
-# build of ``torch``, ``onnxruntime`` and ``numba``) required for the
-# sequence model and style embedding features.
+# also install optional machine learning libraries (``numpy`` pinned to
+# ``<2`` for compatibility with project dependencies, the CPU build of
+# ``torch``, ``onnxruntime`` and ``numba``) required for the sequence
+# model and style embedding features.
 #----------------------------------------------------------------------
 set -euo pipefail
 
@@ -95,7 +101,7 @@ main() {
         echo "DRY RUN: pip install -r requirements.txt"
         echo "DRY RUN: pip install -e ."
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            echo "DRY RUN: pip install numpy"
+            echo "DRY RUN: pip install \"numpy<2\""  # Pin <2 to prevent core dependency conflicts
             echo "DRY RUN: pip install torch --index-url https://download.pytorch.org/whl/cpu"
             echo "DRY RUN: pip install onnxruntime"
             echo "DRY RUN: pip install numba"
@@ -107,7 +113,7 @@ main() {
         run_cmd pip install -r requirements.txt
         run_cmd pip install -e .
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            run_cmd pip install numpy
+            run_cmd pip install "numpy<2"  # Pin <2 to prevent core dependency conflicts
             run_cmd pip install torch --index-url https://download.pytorch.org/whl/cpu
             run_cmd pip install onnxruntime
             run_cmd pip install numba

--- a/scripts/setup_windows.ps1
+++ b/scripts/setup_windows.ps1
@@ -8,7 +8,14 @@ creates a virtual environment in ./venv and installs project dependencies.
 Set the environment variable DRY_RUN=1 to print commands without executing
 them. Set INSTALL_ML_DEPS=1 to install optional machine learning libraries
 (numpy, the CPU build of torch, onnxruntime and numba) used by the sequence
-model and style embedding features.
+model and style embedding features. ``numpy`` is pinned to versions below 2
+to remain compatible with the project's core dependency constraints.
+#
+.NOTES
+Modification summary:
+- Pin ``numpy`` to versions below 2 when optionally installing machine
+  learning dependencies. The pin avoids conflicts with the project's core
+  dependency constraints which currently expect the 1.x series.
 #>
 
 $ErrorActionPreference = 'Stop'
@@ -58,7 +65,7 @@ function main {
         Write-Host 'DRY RUN: pip install -r requirements.txt'
         Write-Host 'DRY RUN: pip install -e .'
         if ($env:INSTALL_ML_DEPS -eq '1') {
-            Write-Host 'DRY RUN: pip install numpy'
+            Write-Host 'DRY RUN: pip install "numpy<2"'  # Pin <2 to prevent core dependency conflicts
             Write-Host 'DRY RUN: pip install torch --index-url https://download.pytorch.org/whl/cpu'
             Write-Host 'DRY RUN: pip install onnxruntime'
             Write-Host 'DRY RUN: pip install numba'
@@ -70,7 +77,7 @@ function main {
         Run-Command 'pip install -r requirements.txt'
         Run-Command 'pip install -e .'
         if ($env:INSTALL_ML_DEPS -eq '1') {
-            Run-Command 'pip install numpy'
+            Run-Command 'pip install "numpy<2"'  # Pin <2 to prevent core dependency conflicts
             Run-Command 'pip install torch --index-url https://download.pytorch.org/whl/cpu'
             Run-Command 'pip install onnxruntime'
             Run-Command 'pip install numba'


### PR DESCRIPTION
## Summary
- pin numpy<2 when installing optional ML dependencies on Linux, macOS, and Windows
- document version pin to avoid conflicts with core requirements

## Testing
- `pip install -e .`
- `pytest` *(fails: test_cli_gui_integration.py::test_generate_button_click, test_gui_initialization.py::test_generate_runs_in_worker_thread)*