### PR TITLE
Fail fast on command errors in Windows setup script

### DIFF
--- a/tests/test_setup_windows_script.py
+++ b/tests/test_setup_windows_script.py
@@ -31,3 +31,11 @@ def test_python_refresh() -> None:
     """``Get-Command python`` should appear at least twice to refresh the environment."""
     content = SCRIPT_PATH.read_text(encoding="utf-8")
     assert content.count("Get-Command python") >= 2
+
+
+def test_run_command_exit_check() -> None:
+    """Run-Command must halt on failures to avoid partial installations."""
+    content = SCRIPT_PATH.read_text(encoding="utf-8")
+    # The script should explicitly reference $LASTEXITCODE and raise a clear error.
+    assert "$LASTEXITCODE" in content
+    assert "Command failed with exit code" in content


### PR DESCRIPTION
## Summary
- capture and check `$LASTEXITCODE` in `Run-Command`
- halt setup with a clear error when a command fails
- add regression test to ensure failure detection logic remains present

## Testing
- `pytest` *(fails: AttributeError: module 'filedialog' has no attribute 'asksaveasfilename')*
- `pytest tests/test_setup_windows_script.py tests/test_setup_windows.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60287bb9883219637bcae1e74e2a5