### PR TITLE
chore: simplify optional ML deps

### DIFF
--- a/melody_generator/cli.py
+++ b/melody_generator/cli.py
@@ -199,7 +199,6 @@ def run_cli() -> None:
             generate_harmony_line,
             generate_counterpoint_melody,
             create_midi_file,
-            load_sequence_model,
             load_genre_sequence_model,
             get_style_vector,
             _open_default_player,

--- a/melody_generator/gui.py
+++ b/melody_generator/gui.py
@@ -45,6 +45,7 @@ from tempfile import NamedTemporaryFile
 import random
 import webbrowser
 from pathlib import Path
+from functools import partial
 
 from . import diatonic_chords, MIN_OCTAVE, MAX_OCTAVE
 from .sequence_model import load_sequence_model
@@ -784,7 +785,10 @@ class MelodyGeneratorGUI:
                 humanize=params["humanize"],
             )
         except Exception as exc:  # pragma: no cover - rare failures
-            self.root.after(0, lambda: self._generation_complete(error=exc))
+            # Use ``functools.partial`` to bind ``exc`` for the callback executed
+            # on the main thread, preventing linter warnings about an unused
+            # variable while still surfacing the original exception.
+            self.root.after(0, partial(self._generation_complete, error=exc))
         else:
             self.root.after(
                 0,

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -14,9 +14,9 @@
 #   * Consolidate the index refresh so it runs once in ``main``; helper
 #     functions assume the cache is already updated for consistent
 #     package resolution.
-#   * Pin ``numpy`` to versions below 2 when optionally installing machine
-#     learning dependencies. The pin avoids conflicts with the project's
-#     core dependency constraints which currently expect the 1.x series.
+#   * Drop the explicit ``numpy`` installation from optional ML dependencies
+#     because ``requirements.txt`` already constrains NumPy to versions
+#     below 2, keeping it compatible with the rest of the project.
 #
 # Usage:
 #   ./setup_linux.sh
@@ -25,10 +25,10 @@
 # executing them. This is useful for verifying the commands on systems
 # where sudo privileges might be restricted. Set INSTALL_ML_DEPS=1 to also
 # install optional machine learning libraries used by the sequence model
-# and style embedding features. When enabled the script installs ``numpy``
-# (pinned to <2 to maintain compatibility with the rest of the project),
-# ``torch`` (CPU build), ``onnxruntime`` and ``numba`` in the virtual
-# environment.
+# and style embedding features. When enabled the script installs the CPU
+# build of ``torch``, ``onnxruntime`` and ``numba`` in the virtual
+# environment. NumPy is already installed from ``requirements.txt`` with a
+# ``<2`` pin, so it is not repeated here.
 #----------------------------------------------------------------------
 set -euo pipefail
 
@@ -113,7 +113,7 @@ main() {
         echo "DRY RUN: pip install -r requirements.txt"
         echo "DRY RUN: pip install -e ."
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            echo "DRY RUN: pip install \"numpy<2\""  # Pin <2 to prevent core dependency conflicts
+            # NumPy is pinned to <2 in requirements.txt, so only ML extras are installed here.
             echo "DRY RUN: pip install torch --index-url https://download.pytorch.org/whl/cpu"
             echo "DRY RUN: pip install onnxruntime"
             echo "DRY RUN: pip install numba"
@@ -125,7 +125,7 @@ main() {
         run_cmd pip install -r requirements.txt
         run_cmd pip install -e .
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            run_cmd pip install "numpy<2"  # Pin <2 to prevent core dependency conflicts
+            # requirements.txt already provides NumPy (<2); install only ML extras.
             run_cmd pip install torch --index-url https://download.pytorch.org/whl/cpu
             run_cmd pip install onnxruntime
             run_cmd pip install numba

--- a/scripts/setup_mac.sh
+++ b/scripts/setup_mac.sh
@@ -7,9 +7,9 @@
 # installations are reused when possible.
 #
 # Modification summary:
-#   * Pin ``numpy`` to versions below 2 when optionally installing machine
-#     learning dependencies. The pin avoids conflicts with the project's
-#     core dependency constraints which currently expect the 1.x series.
+#   * Drop the explicit ``numpy`` installation from optional ML dependencies
+#     because ``requirements.txt`` already constrains NumPy to versions
+#     below 2, keeping it compatible with the rest of the project.
 #   * Refresh Homebrew's package index before installing packages and use the
 #     actively maintained ``fluid-soundfont`` formula instead of the deprecated
 #     ``fluid-soundfont-gm``.
@@ -20,10 +20,11 @@
 # Set the environment variable DRY_RUN=1 to print commands without
 # executing them. The FORCE_MAC=1 variable allows running the script on
 # non-macOS systems (useful for CI testing). Set INSTALL_ML_DEPS=1 to
-# also install optional machine learning libraries (``numpy`` pinned to
-# ``<2`` for compatibility with project dependencies, the CPU build of
+# also install optional machine learning libraries (the CPU build of
 # ``torch``, ``onnxruntime`` and ``numba``) required for the sequence
-# model and style embedding features.
+# model and style embedding features. NumPy is installed from
+# ``requirements.txt`` and pinned to ``<2`` there, so it is not repeated
+# in the optional section.
 #----------------------------------------------------------------------
 set -euo pipefail
 
@@ -111,7 +112,7 @@ main() {
         echo "DRY RUN: pip install -r requirements.txt"
         echo "DRY RUN: pip install -e ."
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            echo "DRY RUN: pip install \"numpy<2\""  # Pin <2 to prevent core dependency conflicts
+            # NumPy is pinned to <2 in requirements.txt, so only ML extras are installed here.
             echo "DRY RUN: pip install torch --index-url https://download.pytorch.org/whl/cpu"
             echo "DRY RUN: pip install onnxruntime"
             echo "DRY RUN: pip install numba"
@@ -123,7 +124,7 @@ main() {
         run_cmd pip install -r requirements.txt
         run_cmd pip install -e .
         if [[ "${INSTALL_ML_DEPS:-0}" == "1" ]]; then
-            run_cmd pip install "numpy<2"  # Pin <2 to prevent core dependency conflicts
+            # requirements.txt already provides NumPy (<2); install only ML extras.
             run_cmd pip install torch --index-url https://download.pytorch.org/whl/cpu
             run_cmd pip install onnxruntime
             run_cmd pip install numba

--- a/scripts/setup_windows.ps1
+++ b/scripts/setup_windows.ps1
@@ -7,9 +7,10 @@ Installs Python and supporting libraries using winget if necessary, then
 creates a virtual environment in ./venv and installs project dependencies.
 Set the environment variable DRY_RUN=1 to print commands without executing
 them. Set INSTALL_ML_DEPS=1 to install optional machine learning libraries
-(numpy, the CPU build of torch, onnxruntime and numba) used by the sequence
-model and style embedding features. ``numpy`` is pinned to versions below 2
-to remain compatible with the project's core dependency constraints.
+(the CPU build of torch, onnxruntime and numba) used by the sequence
+model and style embedding features. NumPy is installed from the project's
+``requirements.txt``, which already pins it to versions below 2 to remain
+compatible with the core dependency constraints.
 
 Safeguards:
 - Validates that ``winget`` exists before attempting installations to avoid
@@ -34,9 +35,9 @@ Modification summary:
 - Perform non-interactive ``winget`` installs by accepting agreements.
 - Refresh the environment after installing Python and warn if the interpreter
   cannot be located.
-- Pin ``numpy`` to versions below 2 when optionally installing machine
-  learning dependencies. The pin avoids conflicts with the project's core
-  dependency constraints which currently expect the 1.x series.
+ - Drop the explicit ``numpy`` installation from optional ML dependencies
+   because ``requirements.txt`` already constrains NumPy to versions
+   below 2, keeping it compatible with the rest of the project.
 - Capture command exit codes in ``Run-Command`` and abort on failure to avoid
   silently continuing after errors.
 #>
@@ -179,7 +180,7 @@ function main {
         Write-Host 'DRY RUN: pip install -r requirements.txt'
         Write-Host 'DRY RUN: pip install -e .'
         if ($env:INSTALL_ML_DEPS -eq '1') {
-            Write-Host 'DRY RUN: pip install "numpy<2"'  # Pin <2 to prevent core dependency conflicts
+            # NumPy is pinned to <2 in requirements.txt, so only ML extras are installed here.
             Write-Host 'DRY RUN: pip install torch --index-url https://download.pytorch.org/whl/cpu'
             Write-Host 'DRY RUN: pip install onnxruntime'
             Write-Host 'DRY RUN: pip install numba'
@@ -191,7 +192,7 @@ function main {
         Run-Command 'pip install -r requirements.txt'
         Run-Command 'pip install -e .'
         if ($env:INSTALL_ML_DEPS -eq '1') {
-            Run-Command 'pip install "numpy<2"'  # Pin <2 to prevent core dependency conflicts
+            # requirements.txt already provides NumPy (<2); install only ML extras.
             Run-Command 'pip install torch --index-url https://download.pytorch.org/whl/cpu'
             Run-Command 'pip install onnxruntime'
             Run-Command 'pip install numba'

--- a/tests/test_gui_initialization.py
+++ b/tests/test_gui_initialization.py
@@ -213,10 +213,23 @@ def test_generate_runs_in_worker_thread(monkeypatch):
     monkeypatch.setattr(gui_mod.MelodyGeneratorGUI, "_build_widgets", minimal_build)
 
     # Prevent dialogs from blocking the test.
-    monkeypatch.setattr(gui_mod.filedialog, "asksaveasfilename", lambda **k: "out.mid")
-    monkeypatch.setattr(gui_mod.messagebox, "showinfo", lambda *a, **k: None)
-    monkeypatch.setattr(gui_mod.messagebox, "askyesno", lambda *a, **k: False)
-    monkeypatch.setattr(gui_mod.messagebox, "showerror", lambda *a, **k: None)
+    # ``tkinter.filedialog`` may lack ``asksaveasfilename`` in the stub module,
+    # so allow creation of the attribute during monkeypatching.
+    monkeypatch.setattr(
+        gui_mod.filedialog,
+        "asksaveasfilename",
+        lambda **k: "out.mid",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        gui_mod.messagebox, "showinfo", lambda *a, **k: None, raising=False
+    )
+    monkeypatch.setattr(
+        gui_mod.messagebox, "askyesno", lambda *a, **k: False, raising=False
+    )
+    monkeypatch.setattr(
+        gui_mod.messagebox, "showerror", lambda *a, **k: None, raising=False
+    )
 
     thread_calls = {}
 


### PR DESCRIPTION
## Summary
- avoid redundant numpy install in optional setup scripts
- document that requirements.txt already pins numpy
- capture worker thread exceptions with functools.partial to satisfy linter
- remove unused sequence model import from CLI
- stabilize GUI tests with dummy progress/root objects and flexible monkeypatching

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a627b1386c8321b7e1fb2a24e86496