### PR TITLE
Normalize key inputs in harmony helpers

### DIFF
--- a/melody_generator/harmony_generator.py
+++ b/melody_generator/harmony_generator.py
@@ -24,6 +24,8 @@ Example
 # 2024-12-07: Restricted allowable time signature denominators to common
 # simple values (1, 2, 4, 8, 16) to mirror ``validate_time_signature`` and
 # avoid unsupported meters.
+# 2025-02-16: Normalised key inputs with ``canonical_key`` so helpers accept
+# lowercase or mixed-case values.
 
 from __future__ import annotations
 
@@ -57,10 +59,15 @@ def _degree_to_chord(key: str, idx: int) -> str:
     Chords default to major, minor or diminished triads derived from the
     key signature.  When the resulting name is unknown a random fallback from
     ``CHORDS`` is used so the output always contains valid chord symbols.
+
+    The ``key`` argument is normalised via :func:`canonical_key` so callers
+    may supply any casing (e.g. ``"c"`` or ``"Am"``).
     """
 
-    from . import SCALE, CHORDS
+    from . import SCALE, CHORDS, canonical_key
 
+    # Normalise the key before looking up scale notes and qualities.
+    key = canonical_key(key)
     notes = SCALE[key]
     is_minor = key.endswith("m")
 
@@ -93,7 +100,8 @@ def generate_progression(key: str, length: int = 4) -> Tuple[List[str], List[flo
     Parameters
     ----------
     key:
-        Musical key used to derive chord qualities. Must exist in ``SCALE``.
+        Musical key used to derive chord qualities. The value is
+        case-insensitive and normalised via :func:`canonical_key`.
     length:
         Number of chords to return. Defaults to ``4``.
 
@@ -109,10 +117,11 @@ def generate_progression(key: str, length: int = 4) -> Tuple[List[str], List[flo
         If ``key`` is unknown or ``length`` is non-positive.
     """
 
-    from . import SCALE
+    from . import canonical_key
 
-    if key not in SCALE:
-        raise ValueError(f"Unknown key '{key}'")
+    # Normalize and validate the supplied key; ``canonical_key`` raises
+    # ``ValueError`` for unknown keys.
+    key = canonical_key(key)
     if length <= 0:
         raise ValueError("length must be positive")
 

--- a/tests/test_harmony_generator.py
+++ b/tests/test_harmony_generator.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 import types
 import pytest
+import random
 
 # Stub optional GUI/MIDI libs so the package imports cleanly.
 stub_mido = types.ModuleType("mido")
@@ -68,7 +69,8 @@ def _patch_deps(monkeypatch):
 def test_generate_progression_lengths():
     """Progression generator returns chords and rhythm of requested length."""
     harmony = importlib.import_module("melody_generator.harmony_generator")
-    chords, rhythm = harmony.generate_progression("C", length=4)
+    # Use lowercase key to ensure canonicalisation works transparently.
+    chords, rhythm = harmony.generate_progression("c", length=4)
     assert len(chords) == 4
     assert len(rhythm) == 4
 
@@ -78,8 +80,21 @@ def test_degree_to_chord_diminished():
 
     harmony = importlib.import_module("melody_generator.harmony_generator")
     # In C major the leading tone (degree seven) forms a B diminished triad.
-    chord = harmony._degree_to_chord("C", 6)
+    # Pass the key in lowercase to verify case-insensitive handling.
+    chord = harmony._degree_to_chord("c", 6)
     assert chord == "Bdim"
+
+
+def test_generate_progression_canonicalizes_key():
+    """Lowercase keys should yield the same results as uppercase keys."""
+
+    harmony = importlib.import_module("melody_generator.harmony_generator")
+    random.seed(0)
+    chords_upper, rhythm_upper = harmony.generate_progression("C", length=4)
+    random.seed(0)
+    chords_lower, rhythm_lower = harmony.generate_progression("c", length=4)
+    assert chords_upper == chords_lower
+    assert rhythm_upper == rhythm_lower
 
 
 def test_harmony_generator_rule_based():

--- a/tests/test_melody.py
+++ b/tests/test_melody.py
@@ -522,6 +522,25 @@ def test_diatonic_chords_invalid_key():
         melody_generator.diatonic_chords("H")
 
 
+def test_random_progression_canonicalizes_key():
+    """Lowercase keys should produce the same progression as uppercase."""
+
+    random.seed(0)
+    upper = melody_generator.generate_random_chord_progression("C", 4)
+    random.seed(0)
+    lower = melody_generator.generate_random_chord_progression("c", 4)
+    assert upper == lower
+
+
+def test_diatonic_chords_canonicalizes_key():
+    """Key helpers normalise case via ``canonical_key``."""
+
+    # Major key canonicalisation
+    assert melody_generator.diatonic_chords("c") == melody_generator.diatonic_chords("C")
+    # Minor key canonicalisation
+    assert melody_generator.diatonic_chords("am") == melody_generator.diatonic_chords("Am")
+
+
 def test_counterpoint_invalid_key():
     """``generate_counterpoint_melody`` should validate the key argument."""
 


### PR DESCRIPTION
## Summary
- canonicalize key arguments at the start of generate_random_chord_progression, diatonic_chords, generate_progression, and _degree_to_chord
- expand tests to ensure lowercase and mixed-case keys produce identical results

## Testing
- `ruff check melody_generator/__init__.py melody_generator/harmony_generator.py tests/test_melody.py tests/test_harmony_generator.py`
- `pytest tests/test_melody.py::test_random_progression_canonicalizes_key tests/test_melody.py::test_diatonic_chords_canonicalizes_key tests/test_harmony_generator.py::test_generate_progression_lengths tests/test_harmony_generator.py::test_degree_to_chord_diminished tests/test_harmony_generator.py::test_generate_progression_canonicalizes_key -q`

------
https://chatgpt.com/codex/tasks/task_e_68a74e3547708321adaff7e8183bd48d