### PR TITLE
Annotate create_midi_file return type

### DIFF
--- a/melody_generator/midi_io.py
+++ b/melody_generator/midi_io.py
@@ -14,6 +14,8 @@ Modification summary
   jitter affects every part of the composition rather than only the melody.
 * Imports from ``mido`` are deferred inside ``create_midi_file`` so the module
   can load even when the optional dependency is missing.
+* ``create_midi_file`` advertises its ``MidiFile`` return type for clearer
+  static type checking and easier inspection in tests.
 
 This module contains the low-level helpers used to render melodies as MIDI and
 open the resulting files with the user's default player. It is separated from
@@ -28,7 +30,12 @@ import math
 import random
 import threading
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    # ``MidiFile`` is only needed for type checking to avoid requiring the
+    # optional dependency at import time.
+    from mido import MidiFile
 
 from . import (
     CHORDS,
@@ -53,7 +60,7 @@ def create_midi_file(
     chords_separate: bool = True,
     program: int = 0,
     humanize: bool = True,
-    ) -> object:
+    ) -> "MidiFile":
     """Write ``melody`` to ``output_file`` as a MIDI file.
 
     The generated ``MidiFile`` is returned so callers and tests can inspect the
@@ -64,6 +71,12 @@ def create_midi_file(
     directory of ``output_file`` is created automatically so callers may supply
     paths in a new folder without preparing it beforehand. Notes starting a
     measure receive a small velocity accent to provide a subtle rhythmic pulse.
+
+    Returns
+    -------
+    MidiFile
+        In-memory representation of the written file for further inspection or
+        reuse without reloading from disk.
     """
     # ``mido`` is imported lazily so projects depending on this module do not
     # need the optional MIDI dependency unless they actually render files.  A

--- a/tests/test_midi_io.py
+++ b/tests/test_midi_io.py
@@ -1,9 +1,14 @@
-"""Unit tests for ``midi_io``'s error handling.
+"""Unit tests for ``midi_io``'s behaviour and error handling.
 
-These tests ensure ``create_midi_file`` provides a helpful message when the
-optional ``mido`` dependency is absent.  ``monkeypatch`` is used to simulate the
-module being unavailable so the function's error path can be exercised without
-manipulating the environment.
+The suite verifies two key aspects:
+
+* ``create_midi_file`` returns a ``MidiFile`` instance when the ``mido``
+  dependency is available. This ensures callers can rely on the object type for
+  further processing or inspection without reloading the written file.
+* ``create_midi_file`` provides a helpful message when the optional ``mido``
+  dependency is absent. ``monkeypatch`` simulates the module being unavailable so
+  the function's error path can be exercised without manipulating the
+  environment.
 
 Example
 -------
@@ -23,6 +28,23 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from melody_generator import midi_io  # noqa: E402  # isort:skip
+
+
+def test_create_midi_file_returns_midifile(tmp_path):
+    """``create_midi_file`` should return the ``MidiFile`` object it writes.
+
+    A minimal one-note melody is rendered to a temporary path. The function
+    returns the in-memory ``MidiFile`` instance so callers can further inspect
+    or modify the result without reloading it from disk. The test asserts the
+    returned object is of the expected type.
+    """
+
+    from mido import MidiFile
+
+    out = tmp_path / "song.mid"
+    mid = midi_io.create_midi_file(["C4"], 120, (4, 4), str(out))
+
+    assert isinstance(mid, MidiFile)
 
 
 def test_create_midi_file_missing_mido(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- specify that `create_midi_file` returns a `MidiFile` and update its documentation
- add a test confirming `create_midi_file` returns a `MidiFile`

## Testing
- `ruff check melody_generator/midi_io.py tests/test_midi_io.py`
- `pytest tests/test_midi_io.py -q`